### PR TITLE
fix: fixes various typos

### DIFF
--- a/backend/src/curation.schema.js
+++ b/backend/src/curation.schema.js
@@ -161,7 +161,7 @@ export const curationSchema = Type.Object(
     tags: Type.Array(Type.String()), // list of zero or more lower-case strings
     representativeFile: Type.Optional(Type.Union([Type.Null(), fileSummary])), // if applicable
     promoted: Type.Optional(Type.Array(Type.Any())), // an array of promotionSchema
-    keywordRefs: Type.Optional(Type.Array(Type.String())), // used for pre-emptive "cleanup" prior to recalculating keywords
+    keywordRefs: Type.Optional(Type.Array(Type.String())), // used for preemptive "cleanup" prior to recalculating keywords
   }
 )
 

--- a/backend/src/services/preferences/helpers.js
+++ b/backend/src/services/preferences/helpers.js
@@ -23,7 +23,7 @@ export const validateFileVersionPayload = context => {
   }
   for (let fileVersion of context.data.version.files) {
     if (!fileVersion.fileName || !fileVersion.uniqueFileName) {
-      throw new BadRequest('fileName or uniqueFileName cant be empty');
+      throw new BadRequest('fileName or uniqueFileName cannot be empty');
     }
   }
 };

--- a/backend/src/services/shared-models/helpers.js
+++ b/backend/src/services/shared-models/helpers.js
@@ -85,7 +85,7 @@ export const handleDirectSharedToUsers = async context => {
 }
 
 export async function buildFakeModelAndFileForActiveVersion(message, context) {
-  // this function pulls from the DB to generate a psuedo Model and subtending File
+  // this function pulls from the DB to generate a pseudo Model and subtending File
   let finalModel = null;
   let {refFile, refModel} = await getReferenceFileAndModel(message, context);
 

--- a/backend/src/services/shared-models/shared-models.js
+++ b/backend/src/services/shared-models/shared-models.js
@@ -481,7 +481,7 @@ const createUserInstance = async (context) => {
     }
 
   } else if (!result.data[0].objUrl && !result.data[0].error) {
-    // Incase if mesh was not generated earlier
+    // In case mesh was not generated earlier
     await modelService.patch(result.data[0]._id, { shouldStartObjGeneration: true }, context.params)
   }
 

--- a/backend/src/services/workspaces/workspaces.curation.js
+++ b/backend/src/services/workspaces/workspaces.curation.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// A "curation" file is for visibly decorating an object and handling pre-emptive keyword indexing (for later searches.)
+// A "curation" file is for visibly decorating an object and handling preemptive keyword indexing (for later searches.)
 //
 
 import {generateAndApplyKeywords, navTargetMap} from "../../curation.schema.js";

--- a/frontend/src/components/Feed.vue
+++ b/frontend/src/components/Feed.vue
@@ -75,13 +75,13 @@ export default {
           parser.parseString(text, (err, parsed) => {
             this.loading = false;
             if (err) {
-              this.error = `Error occured while parsing RSS Feed ${err.toString()}`;
+              this.error = `Error occurred while parsing RSS Feed ${err.toString()}`;
             } else {
               this.feed = parsed;
             }
           });
         } else {
-          this.error = "Error occured while fetching the feed";
+          this.error = "Error occurred while fetching the feed";
           this.loading = false;
         }
       } catch (e) {


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,childs,ppcheck,som,te,ue,vew,zar`