### PR TITLE
Feature: Added support to run LENS from prebuilds docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ docker-compose build --no-cache frontend
 
 # For development:
 docker-compose -f docker-compose.dev.yml --profile matomo-enabled up --build -d
+
+# To use prebuild docker images
+docker-compose -f docker-compose.prebuilds.yml --profile matomo-enabled up --build -d
 ```
 
 That's it! The application should now be running at http://localhost:3000

--- a/docker-compose.prebuilds.yml
+++ b/docker-compose.prebuilds.yml
@@ -1,0 +1,112 @@
+services:
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "${EXPOSE_DB_PORT:-27018}:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+  backend:
+    image: amrit3701/lens:backend-latest
+    ports:
+      - "3030:3030"
+    environment:
+      - HOSTNAME=${HOSTNAME:-localhost}
+      - PORT=${PORT:-3030}
+      - DB_URL=mongodb://mongodb:27017/backend-db
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - FC_WORKER_URL=http://0.0.0.0:8080/2015-03-31/functions/function/invocations
+      - SMTP_HOST
+      - SMTP_PORT=${SMTP_PORT:-465}
+      - SMTP_USER
+      - SMTP_PASS
+      - USE_S3
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_CLIENT_MODELS_BUCKET
+      - AWS_REGION
+      - DEFAULT_ADMIN_EMAIL
+      - DEFAULT_ADMIN_USERNAME
+      - DEFAULT_ADMIN_PASSWORD
+      - DEFAULT_ADMIN_NAME
+      - LOCAL_SIGNED_URL_SECRET
+    volumes:
+      - uploads_data:/app/uploads
+    depends_on:
+      - mongodb
+
+  frontend:
+    image: amrit3701/lens:frontend-latest
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+
+  fc-worker-redis:
+    image: redis:alpine
+
+  fc-worker-api:
+    image: amrit3701/lens:fc-worker-api-latest
+    environment:
+      - REDIS_HOST=fc-worker-redis
+      - REDIS_PORT=6379
+    network_mode: "service:backend"
+    depends_on:
+      - backend
+      - fc-worker-redis
+
+  fc-worker-celery:
+    image: amrit3701/lens:fc-worker-celery-latest
+    environment:
+      - REDIS_HOST=fc-worker-redis
+      - REDIS_PORT=6379
+      - BACKEND_URL=${BACKEND_URL:-http://localhost:3030}
+    network_mode: "service:backend"
+    depends_on:
+      - backend
+      - fc-worker-redis
+
+  matomo-db:
+    profiles:
+      - matomo-enabled
+    image: mariadb:11.4.4
+    command: --max-allowed-packet=128M
+    environment:
+      - MYSQL_ROOT_PASSWORD=matomo
+      - MYSQL_DATABASE=matomo
+      - MYSQL_USER=matomo 
+      - MYSQL_PASSWORD=matomo
+    volumes:
+      - matomo_db:/var/lib/mysql
+
+  matomo:
+    profiles:
+      - matomo-enabled
+    image: docker.io/bitnami/matomo:5
+    ports:
+      - "7000:8080"
+    environment:
+      - MATOMO_DATABASE_HOST=matomo-db
+      - MATOMO_DATABASE_TABLE_PREFIX=matomo_
+      - MATOMO_DATABASE_USER=matomo
+      - MATOMO_DATABASE_PASSWORD=matomo
+      - MATOMO_DATABASE_NAME=matomo
+      - MATOMO_WEBSITE_NAME=Ondsel LENS
+      - MATOMO_WEBSITE_HOST=${FRONTEND_URL:-http://localhost:3000}
+      - MATOMO_USERNAME=${MATOMO_USERNAME:-admin}
+      - MATOMO_PASSWORD=${MATOMO_PASSWORD:-admin@local.test}
+      - MATOMO_EMAIL=${MATOMO_EMAIL:-admin@local.test}
+    volumes:
+      - matomo_data:/bitnami/matomo
+    depends_on:
+      - matomo-db
+
+volumes:
+  mongodb_data:
+    name: mongodb_data
+  uploads_data:
+    name: uploads_data
+  matomo_db:
+    name: matomo_db
+  matomo_data:
+    name: matomo_data 


### PR DESCRIPTION
### To use prebuild docker images

```sh
docker-compose -f docker-compose.prebuilds.yml --profile matomo-enabled up --build
```

#### Docker hub registry

https://hub.docker.com/repository/docker/amrit3701/lens/general