### PR TITLE
Remove link to Ondsel ES downloads page, fix grammar

### DIFF
--- a/frontend/src/layouts/default/MainNavigationBar.vue
+++ b/frontend/src/layouts/default/MainNavigationBar.vue
@@ -306,7 +306,7 @@ export default {
         },
         {
           icon: 'mdi-inbox',
-          title: 'Shared With Me',
+          title: 'Shared with Me',
           condition: this.user,
           route: {name: 'SharedWithMe'}
         },
@@ -315,12 +315,6 @@ export default {
           title: 'Bookmarks',
           condition: this.user,
           route: {name: 'Bookmarks'}
-        },
-        {
-          icon: 'mdi-download-outline',
-          title: 'Download Ondsel ES',
-          condition: true,
-          route: {name: 'DownloadAndExplore'}
         },
       ].filter(item => item.condition);
     },


### PR DESCRIPTION
The navigation bar shouldn't be linking to the page with Ondsel ES builds. I did not remove the download-and-explore page itself though.

Also, fix edthe title case in one user-visible massage.

@amrit3701 FYI