### PR TITLE
Add Github OAuth login support

### DIFF
--- a/backend/src/authentication.js
+++ b/backend/src/authentication.js
@@ -8,7 +8,7 @@ import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication'
 import { LocalStrategy } from '@feathersjs/authentication-local'
 import { oauth } from '@feathersjs/authentication-oauth'
 import { NotFound } from '@feathersjs/errors'
-import { GoogleStrategy } from './authentication/oauth-helper.js'
+import { GitHubStrategy, GoogleStrategy } from './authentication/oauth-helper.js'
 import { createRequire } from 'module'
 
 const require = createRequire(import.meta.url)
@@ -103,12 +103,16 @@ async function configureOAuth(app, authentication) {
   const providerConfigs = app.get('oauthProviderConfigs') || {}
 
   // Build OAuth config for Grant
-  const oauthConfig = providerConfigs.google ? { google: { ...providerConfigs.google } } : {}
+  const oauthConfig = {
+    ...(providerConfigs.google ? { google: { ...providerConfigs.google } } : {}),
+    ...(providerConfigs.github ? { github: { ...providerConfigs.github } } : {})
+  }
 
   const currentAuthConfig = app.get('authentication') || {}
   app.set('authentication', { ...currentAuthConfig, oauth: oauthConfig })
 
   authentication.register('google', new GoogleStrategy())
+  authentication.register('github', new GitHubStrategy())
   app.configure(oauth())
 
   // Patch OAuthService handler to support dynamic config updates
@@ -159,6 +163,19 @@ function updateOAuthProviderConfigs(app, siteConfig) {
       transport: 'state',
       response: ['tokens', 'raw', 'profile'],
       redirect_uri: googleConfig.redirectUri
+    }
+  }
+
+  const githubConfig = siteConfig?.oauth?.providers?.github
+  if (githubConfig?.enabled && githubConfig.clientId && githubConfig.clientSecret) {
+    providerConfigs.github = {
+      ...grantOAuthDefaults.github,
+      key: githubConfig.clientId,
+      secret: githubConfig.clientSecret,
+      scope: 'user:email',
+      transport: 'state',
+      response: ['tokens', 'raw', 'profile'],
+      redirect_uri: githubConfig.redirectUri
     }
   }
 

--- a/backend/src/authentication/oauth-helper.js
+++ b/backend/src/authentication/oauth-helper.js
@@ -44,37 +44,14 @@ export function verifyOAuthCompletionSignature(encodedData, expires, signature, 
 }
 
 /**
- * Google OAuth Strategy
+ * Base OAuth Strategy with common functionality
  */
-export class GoogleStrategy extends OAuthStrategy {
+class BaseOAuthStrategy extends OAuthStrategy {
   /**
-   * Extract Google provider ID from profile
+   * Extract provider ID from profile
    */
   getProviderId(profile) {
-    return profile.sub || profile.id
-  }
-
-  /**
-   * Fetch user profile from Google's OpenID Connect endpoint
-   */
-  async getProfile(data, params) {
-    const response = await fetch('https://openidconnect.googleapis.com/v1/userinfo', {
-      headers: {
-        Authorization: `Bearer ${data.access_token}`
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error('Failed to fetch user profile from Google')
-    }
-
-    const profile = await response.json()
-
-    if (!profile.email) {
-      throw new Error('Email is required but not provided by Google OAuth')
-    }
-
-    return profile
+    return String(profile.id)
   }
 
   /**
@@ -143,7 +120,7 @@ export class GoogleStrategy extends OAuthStrategy {
         email: oauthProfile.email,
         name: oauthProfile.name || oauthProfile.email.split('@')[0],
         providerId: providerId,
-        suggestedUsername: this.generateUsernameFromEmail(oauthProfile.email)
+        suggestedUsername: oauthProfile.suggestedUsername
       }
 
       const OAUTH_COMPLETION_EXPIRY_SECONDS = 15 * 60 // 15 minutes
@@ -176,8 +153,8 @@ export class GoogleStrategy extends OAuthStrategy {
     const accessToken = await this.authentication.createAccessToken(payload)
 
     return {
-      user: user,
-      accessToken: accessToken
+      user,
+      accessToken
     }
   }
 
@@ -213,11 +190,9 @@ export class GoogleStrategy extends OAuthStrategy {
         id: providerId
       }
 
-      await userService.patch(userId, {
+      const updatedUser = await userService.patch(userId, {
         oauthProviders: existingUserByEmail.oauthProviders
       })
-
-      const updatedUser = await userService.get(userId)
 
       return await this.createLoginToken(updatedUser)
     }
@@ -226,6 +201,96 @@ export class GoogleStrategy extends OAuthStrategy {
     return {
       oauthProfile: profile,
       providerId: providerId
+    }
+  }
+}
+
+/**
+ * Google OAuth Strategy
+ */
+export class GoogleStrategy extends BaseOAuthStrategy {
+  /**
+   * Fetch user profile from Google's OpenID Connect endpoint
+   */
+  async getProfile(data, params) {
+    const response = await fetch('https://openidconnect.googleapis.com/v1/userinfo', {
+      headers: {
+        Authorization: `Bearer ${data.access_token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch user profile from Google')
+    }
+
+    const profile = await response.json()
+
+    if (!profile.email) {
+      throw new Error('Email is required but not provided by Google OAuth')
+    }
+
+    return {
+      id: profile.sub || profile.id,
+      email: profile.email,
+      name: profile.name,
+      suggestedUsername: this.generateUsernameFromEmail(profile.email)
+    }
+  }
+}
+
+/**
+ * GitHub OAuth Strategy
+ */
+export class GitHubStrategy extends BaseOAuthStrategy {
+  /**
+   * Fetch user profile from GitHub API
+   * GitHub requires separate API calls for profile and emails
+   */
+  async getProfile(data, params) {
+    const accessToken = data.access_token
+
+    const profileResponse = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github.v3+json'
+      }
+    })
+
+    if (!profileResponse.ok) {
+      throw new Error('Failed to fetch user profile from GitHub')
+    }
+
+    const profile = await profileResponse.json()
+
+    const emailsResponse = await fetch('https://api.github.com/user/emails', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github.v3+json'
+      }
+    })
+
+    if (!emailsResponse.ok) {
+      throw new Error('Failed to fetch user emails from GitHub')
+    }
+
+    const emails = await emailsResponse.json()
+
+    const primaryEmail = emails.find(email => email.primary && email.verified) ||
+                        emails.find(email => email.verified) ||
+                        emails.find(email => email.primary) ||
+                        emails[0]
+
+    if (!primaryEmail || !primaryEmail.email) {
+      throw new Error('Email is required but not provided by GitHub OAuth')
+    }
+
+    return {
+      id: profile.id,
+      email: primaryEmail.email,
+      name: profile.name,
+      suggestedUsername: profile.login
+        ? profile.login.toLowerCase().replace(/[^a-z0-9_]/g, '')
+        : this.generateUsernameFromEmail(primaryEmail.email)
     }
   }
 }

--- a/backend/src/services/site-config/site-config.schema.js
+++ b/backend/src/services/site-config/site-config.schema.js
@@ -66,6 +66,7 @@ const oauthProviderConfigSchema = Type.Object({
 const oauthConfigSchema = Type.Object({
   providers: Type.Object({
     google: oauthProviderConfigSchema,
+    github: oauthProviderConfigSchema,
   })
 })
 

--- a/backend/src/services/users/users.schema.js
+++ b/backend/src/services/users/users.schema.js
@@ -43,6 +43,9 @@ export const userSchema = Type.Object(
       google: Type.Optional(Type.Object({
         id: Type.String(),
       })),
+      github: Type.Optional(Type.Object({
+        id: Type.String(),
+      })),
     })),
     name: Type.String(),
     firstName: Type.String(), // deprecated
@@ -193,6 +196,7 @@ export const userQuerySchema = Type.Intersect(
       'publicInfo': Type.Optional(Type.String()),
       'getOnlyAccessTokenUser': Type.Optional(Type.String()),
       'oauthProviders.google.id': Type.Optional(Type.String()),
+      'oauthProviders.github.id': Type.Optional(Type.String()),
     }, { additionalProperties: false })
   ],
   { additionalProperties: false }

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -29,7 +29,7 @@ The Xavier admin panel is a hidden administrative interface for site administrat
 | [Brand Identity](#brand-identity) | `/xavier-branding-logo-87654321` | Logo, favicon, title & social links |
 | [Homepage Content](#homepage-content) | `/xavier-branding-homepage-11223344` | Homepage customization |
 | [Default Model](#default-model) | `/xavier-branding-default-model-55667788` | Default 3D model for new users |
-| [OAuth Configuration](#oauth-configuration) | `/xavier-oauth-12345678` | OAuth provider configuration (Google) |
+| [OAuth Configuration](#oauth-configuration) | `/xavier-oauth-12345678` | OAuth provider configuration (Google, GitHub) |
 | [Software Releases](#software-releases) | `/xavier-9384242` | Manage download links |
 | [Key Documents](#key-documents) | `/xavier-7492783/:name` | Legal document management |
 | [Remove User](#remove-user) | `/xavier-55554337898` | User account deletion |
@@ -146,7 +146,7 @@ Upload and configure the default 3D model that appears for new user registration
 
 **Route:** `/xavier-oauth-12345678`
 
-Configure Google OAuth 2.0 authentication to enable social login for users.
+Configure OAuth 2.0 authentication providers to enable social login for users. Currently supports Google and GitHub OAuth.
 
 ### Configurable Options
 
@@ -158,6 +158,14 @@ Configure Google OAuth 2.0 authentication to enable social login for users.
 | Client Secret | Google OAuth 2.0 Client Secret (masked input) |
 | Redirect URI | Auto-generated redirect URI (read-only, copy to Google Cloud Console) |
 
+#### GitHub OAuth
+| Setting | Description |
+|---------|-------------|
+| Enable GitHub OAuth | Toggle to enable/disable GitHub OAuth login |
+| Client ID | GitHub OAuth App Client ID |
+| Client Secret | GitHub OAuth App Client Secret (masked input) |
+| Redirect URI | Auto-generated redirect URI (read-only, copy to GitHub OAuth App settings) |
+
 ### Usage
 
 1. **For Google OAuth:**
@@ -168,17 +176,25 @@ Configure Google OAuth 2.0 authentication to enable social login for users.
    - Enter Client ID and Client Secret
    - Click **Save** to apply changes
 
+2. **For GitHub OAuth:**
+   - Create a GitHub OAuth App in your GitHub organization settings (Settings → Developer settings → OAuth Apps)
+   - Set the Authorization callback URL to match the displayed Redirect URI
+   - Enable GitHub OAuth toggle
+   - Enter Client ID and Client Secret
+   - Click **Save** to apply changes
+
 ### Features
-- Enable/disable toggle for Google OAuth
+- Enable/disable toggles for each OAuth provider (Google, GitHub)
 - Secure credential storage (secrets are masked)
-- Auto-generated redirect URI
-- "Sign in with Google" button appears on login page when enabled
+- Auto-generated redirect URIs for each provider
+- "Sign in with Google" button appears on login page when Google OAuth enabled
+- "Sign in with GitHub" button appears on login page when GitHub OAuth enabled
 
 ### Security Notes
 - OAuth credentials are stored securely in the site-config service
 - Client secrets are never displayed in plain text
-- Disabling Google OAuth prevents new Google OAuth logins but doesn't affect existing linked accounts
-- Users with Google OAuth-only accounts can still use password reset to regain access
+- Disabling an OAuth provider prevents new logins via that provider but doesn't affect existing linked accounts
+- Users with OAuth-only accounts can still use password reset to regain access
 
 ---
 

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -177,7 +177,7 @@ Configure OAuth 2.0 authentication providers to enable social login for users. C
    - Click **Save** to apply changes
 
 2. **For GitHub OAuth:**
-   - Create a GitHub OAuth App in your GitHub organization settings (Settings → Developer settings → OAuth Apps)
+   - Create a GitHub OAuth App in your GitHub organization settings (Settings → Developer settings → [OAuth Apps](https://github.com/settings/developers))
    - Set the Authorization callback URL to match the displayed Redirect URI
    - Enable GitHub OAuth toggle
    - Enter Client ID and Client Secret

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -81,47 +81,47 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <v-divider></v-divider>
                   </div>
                 </v-col>
+              </v-row>
+              <div v-if="isOAuthRedirecting && (isGoogleOAuthEnabled || isGitHubOAuthEnabled)" class="d-flex flex-column align-center justify-center mt-4" style="min-height: 40px;">
+                <v-progress-circular
+                  indeterminate
+                  color="primary"
+                  size="40"
+                  width="4"
+                ></v-progress-circular>
+                <span class="mt-2 text-caption text-grey">Redirecting to {{ oAuthRedirectingProvider === 'google' ? 'Google' : 'GitHub' }}...</span>
+              </div>
+              <v-row v-else-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled">
                 <v-col v-if="isGoogleOAuthEnabled" cols="12" class="text-center" style="position: relative;">
                   <img 
-                    v-if="!isOAuthRedirecting"
                     src="/img/google-signin-button.svg" 
                     alt="Sign in with Google"
-                    @click="!isAuthenticatePending && !isOAuthRedirecting && loginWithOAuth('google')"
+                    @click="!isAuthenticatePending && loginWithOAuth('google')"
                     :style="{ 
                       height: '40px', 
                       width: 'auto', 
-                      cursor: (isAuthenticatePending || isOAuthRedirecting) ? 'not-allowed' : 'pointer',
-                      opacity: (isAuthenticatePending || isOAuthRedirecting) ? 0.6 : 1,
+                      cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
+                      opacity: isAuthenticatePending ? 0.6 : 1,
                       display: 'block',
                       margin: '0 auto'
                     }"
                     class="google-signin-button"
                   />
-                  <div v-else-if="oAuthRedirectingProvider === 'google'" class="d-flex flex-column align-center">
-                    <v-progress-circular
-                      indeterminate
-                      color="primary"
-                      size="40"
-                      width="4"
-                    ></v-progress-circular>
-                    <span class="mt-2 text-caption text-grey">Redirecting to Google...</span>
-                  </div>
                 </v-col>
                 <v-col v-if="isGitHubOAuthEnabled" cols="12" class="text-center" style="position: relative;">
                   <v-btn
-                    v-if="!isOAuthRedirecting"
                     variant="outlined"
                     size="large"
-                    :disabled="isAuthenticatePending || isOAuthRedirecting"
-                    @click="!isAuthenticatePending && !isOAuthRedirecting && loginWithOAuth('github')"
+                    :disabled="isAuthenticatePending"
+                    @click="!isAuthenticatePending && loginWithOAuth('github')"
                     :style="{ 
                       height: '40px',
                       width: 'auto',
-                      cursor: (isAuthenticatePending || isOAuthRedirecting) ? 'not-allowed' : 'pointer',
-                      opacity: (isAuthenticatePending || isOAuthRedirecting) ? 0.6 : 1,
+                      cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
+                      opacity: isAuthenticatePending ? 0.6 : 1,
                       display: 'inline-flex',
                       backgroundColor: '#FFFFFF',
-                      borderColor: '#dadce0',
+                      borderColor: '#747775',
                       borderWidth: '1px',
                       borderStyle: 'solid',
                       color: '#3c4043 !important',
@@ -136,15 +136,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
                     <span style="color: #3c4043;">Sign in with GitHub</span>
                   </v-btn>
-                  <div v-else-if="oAuthRedirectingProvider === 'github'" class="d-flex flex-column align-center">
-                    <v-progress-circular
-                      indeterminate
-                      color="primary"
-                      size="40"
-                      width="4"
-                    ></v-progress-circular>
-                    <span class="mt-2 text-caption text-grey">Redirecting to GitHub...</span>
-                  </div>
                 </v-col>
               </v-row>
             </v-form>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         </v-card>
         <p></p>
         <v-card :title="`Login to ${siteConfig?.siteTitle}`" width="26em" class="pa-2 mt-16">
-          <v-card-text>
+          <v-card-text :class="{ 'pb-6': !(isGoogleOAuthEnabled || isGitHubOAuthEnabled) }">
             <template v-slot:loader="{ isActive }">
               <v-progress-linear
                 :active="isAuthenticatePending"
@@ -73,7 +73,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 >Submit</v-btn>
               </v-row>
 
-              <v-row v-if="isGoogleOAuthEnabled" class="mt-4">
+              <v-row v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="mt-4">
                 <v-col cols="12">
                   <div class="d-flex align-center my-2">
                     <v-divider></v-divider>
@@ -81,12 +81,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <v-divider></v-divider>
                   </div>
                 </v-col>
-                <v-col cols="12" class="text-center" style="position: relative;">
+                <v-col v-if="isGoogleOAuthEnabled" cols="12" class="text-center" style="position: relative;">
                   <img 
                     v-if="!isOAuthRedirecting"
                     src="/img/google-signin-button.svg" 
                     alt="Sign in with Google"
-                    @click="!isAuthenticatePending && !isOAuthRedirecting && loginWithGoogle()"
+                    @click="!isAuthenticatePending && !isOAuthRedirecting && loginWithOAuth('google')"
                     :style="{ 
                       height: '40px', 
                       width: 'auto', 
@@ -97,7 +97,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     }"
                     class="google-signin-button"
                   />
-                  <div v-else class="d-flex flex-column align-center">
+                  <div v-else-if="oAuthRedirectingProvider === 'google'" class="d-flex flex-column align-center">
                     <v-progress-circular
                       indeterminate
                       color="primary"
@@ -105,6 +105,45 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                       width="4"
                     ></v-progress-circular>
                     <span class="mt-2 text-caption text-grey">Redirecting to Google...</span>
+                  </div>
+                </v-col>
+                <v-col v-if="isGitHubOAuthEnabled" cols="12" class="text-center" style="position: relative;">
+                  <v-btn
+                    v-if="!isOAuthRedirecting"
+                    variant="outlined"
+                    size="large"
+                    :disabled="isAuthenticatePending || isOAuthRedirecting"
+                    @click="!isAuthenticatePending && !isOAuthRedirecting && loginWithOAuth('github')"
+                    :style="{ 
+                      height: '40px',
+                      width: 'auto',
+                      cursor: (isAuthenticatePending || isOAuthRedirecting) ? 'not-allowed' : 'pointer',
+                      opacity: (isAuthenticatePending || isOAuthRedirecting) ? 0.6 : 1,
+                      display: 'inline-flex',
+                      backgroundColor: '#FFFFFF',
+                      borderColor: '#dadce0',
+                      borderWidth: '1px',
+                      borderStyle: 'solid',
+                      color: '#3c4043 !important',
+                      textTransform: 'none',
+                      fontSize: '14px',
+                      fontWeight: '500',
+                      letterSpacing: '0.25px',
+                      padding: '0 16px'
+                    }"
+                    class="github-signin-button"
+                  >
+                    <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
+                    <span style="color: #3c4043;">Sign in with GitHub</span>
+                  </v-btn>
+                  <div v-else-if="oAuthRedirectingProvider === 'github'" class="d-flex flex-column align-center">
+                    <v-progress-circular
+                      indeterminate
+                      color="primary"
+                      size="40"
+                      width="4"
+                    ></v-progress-circular>
+                    <span class="mt-2 text-caption text-grey">Redirecting to GitHub...</span>
                   </div>
                 </v-col>
               </v-row>
@@ -175,6 +214,7 @@ export default {
       isForgotPasswordDialogActive: false,
       isRedirectedFromDownloadPage: false,
       isOAuthRedirecting: false,
+      oAuthRedirectingProvider: null,
     }
   },
   computed: {
@@ -186,6 +226,9 @@ export default {
     },
     isGoogleOAuthEnabled() {
       return this.siteConfig?.oauth?.providers?.google?.enabled === true;
+    },
+    isGitHubOAuthEnabled() {
+      return this.siteConfig?.oauth?.providers?.github?.enabled === true;
     },
   },
   mounted() {
@@ -238,15 +281,16 @@ export default {
       this.isForgotPasswordDialogActive = true;
       this.$refs.forgotPasswordDialog.$data.dialog = true;
     },
-    loginWithGoogle() {
+    loginWithOAuth(provider) {
       if (this.isOAuthRedirecting || this.isAuthenticatePending) {
         return;
       }
 
       this.isOAuthRedirecting = true;
+      this.oAuthRedirectingProvider = provider;
       // Small delay to show loading state before redirect
       setTimeout(() => {
-        window.location.href = `${import.meta.env.VITE_APP_API_URL}oauth/google`;
+        window.location.href = `${import.meta.env.VITE_APP_API_URL}oauth/${provider}`;
       }, 100);
     },
   }

--- a/frontend/src/views/SignUp.vue
+++ b/frontend/src/views/SignUp.vue
@@ -7,7 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <template>
   <v-container fluid>
     <signup-progress-bar step="0" msg="start with the form"></signup-progress-bar>
-    <v-card :title="`Sign Up to ${siteConfig?.siteTitle}`" class="mx-auto mt-8" width="22em" flat>
+    <v-card class="mx-auto mt-8" width="28em" flat>
+      <v-card-title class="text-center pb-4">{{ `Sign Up to ${siteConfig?.siteTitle}` }}</v-card-title>
       <template v-slot:loader="{  }">
         <v-progress-linear
           :active="isCreatePending"
@@ -15,6 +16,69 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           indeterminate
         ></v-progress-linear>
       </template>
+      <v-card-text v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="pb-4">
+        <div v-if="isOAuthRedirecting && (isGoogleOAuthEnabled || isGitHubOAuthEnabled)" class="d-flex flex-column align-center justify-center" style="min-height: 40px;">
+          <v-progress-circular
+            indeterminate
+            color="primary"
+            size="40"
+            width="4"
+          ></v-progress-circular>
+          <span class="mt-2 text-caption text-grey">Redirecting to {{ oAuthRedirectingProvider === 'google' ? 'Google' : 'GitHub' }}...</span>
+        </div>
+        <v-row v-else-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" no-gutters>
+          <v-col v-if="isGoogleOAuthEnabled" :cols="isGitHubOAuthEnabled ? 6 : 12" class="text-center" :class="isGitHubOAuthEnabled ? 'pr-1' : ''" style="position: relative;">
+            <img 
+              src="/img/google-signin-button.svg" 
+              alt="Sign in with Google"
+              @click="!isCreatePending && loginWithOAuth('google')"
+              :style="{ 
+                height: '40px', 
+                width: 'auto', 
+                cursor: isCreatePending ? 'not-allowed' : 'pointer',
+                opacity: isCreatePending ? 0.6 : 1,
+                display: 'block',
+                margin: '0 auto'
+              }"
+              class="google-signin-button"
+            />
+          </v-col>
+          <v-col v-if="isGitHubOAuthEnabled" :cols="isGoogleOAuthEnabled ? 6 : 12" class="text-center" :class="isGoogleOAuthEnabled ? 'pl-1' : ''" style="position: relative;">
+            <v-btn
+              variant="outlined"
+              size="large"
+              :disabled="isCreatePending"
+              @click="!isCreatePending && loginWithOAuth('github')"
+              :style="{ 
+                height: '40px',
+                width: 'auto',
+                cursor: isCreatePending ? 'not-allowed' : 'pointer',
+                opacity: isCreatePending ? 0.6 : 1,
+                display: 'inline-flex',
+                backgroundColor: '#FFFFFF',
+                borderColor: '#747775',
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                color: '#3c4043 !important',
+                textTransform: 'none',
+                fontSize: '14px',
+                fontWeight: '500',
+                letterSpacing: '0.25px',
+                padding: '0 16px'
+              }"
+              class="github-signin-button"
+            >
+              <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
+              <span style="color: #3c4043;">Sign in with GitHub</span>
+            </v-btn>
+          </v-col>
+        </v-row>
+        <div v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="d-flex align-center my-3">
+          <v-divider></v-divider>
+          <span class="mx-4 text-grey">OR</span>
+          <v-divider></v-divider>
+        </div>
+      </v-card-text>
       <v-form v-model="isValid" ref="form" @submit.prevent="signUp">
         <v-text-field
           v-model="user.email"
@@ -217,12 +281,20 @@ export default {
       extraHintContent: '',
       lastBadUsername: '',
       lastBadEmail: '',
+      isOAuthRedirecting: false,
+      oAuthRedirectingProvider: null,
     }
   },
   computed: {
     User: () => models.api.User,
     ...mapGetters('app', ['siteConfig']),
     ...mapState('users', ['isCreatePending']),
+    isGoogleOAuthEnabled() {
+      return this.siteConfig?.oauth?.providers?.google?.enabled === true;
+    },
+    isGitHubOAuthEnabled() {
+      return this.siteConfig?.oauth?.providers?.github?.enabled === true;
+    },
     usageTypes() {
       return [
         { value: 'work', title: `I want to use ${this.siteConfig?.siteTitle} for work` },
@@ -285,6 +357,18 @@ export default {
         return "requires at least 4 characters in derived username";
       }
       return true;
+    },
+    loginWithOAuth(provider) {
+      if (this.isOAuthRedirecting || this.isCreatePending) {
+        return;
+      }
+
+      this.isOAuthRedirecting = true;
+      this.oAuthRedirectingProvider = provider;
+      // Small delay to show loading state before redirect
+      setTimeout(() => {
+        window.location.href = `${import.meta.env.VITE_APP_API_URL}oauth/${provider}`;
+      }, 100);
     },
     extraHintCheck(newRawString) {
       if (this.extraHintContent === '') {

--- a/frontend/src/views/XavierOAuthConfig.vue
+++ b/frontend/src/views/XavierOAuthConfig.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               <v-card-title>Google OAuth</v-card-title>
               <v-card-text>
                 <p class="text-caption text-grey-darken-1 mb-4">
-                  See the <a href="https://github.com/FreeCAD/Ondsel-Server/blob/main/docs/admin-panel.md#oauth-configuration" target="_blank" rel="noopener noreferrer">OAuth Configuration documentation</a> for setup instructions. Use the Redirect URI shown below when configuring your OAuth app.
+                  See the <a href="https://github.com/FreeCAD/Ondsel-Server/blob/main/docs/admin-panel.md#google-oauth" target="_blank" rel="noopener noreferrer">Google OAuth setup instructions</a> in the OAuth Configuration documentation. Use the Redirect URI shown below when configuring your Google OAuth app.
                 </p>
 
                 <v-switch
@@ -77,6 +77,68 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               </v-card-text>
             </v-card>
           </v-col>
+          <v-col cols="12">
+            <v-card class="ma-2" elevation="1">
+              <v-card-title>GitHub OAuth</v-card-title>
+              <v-card-text>
+                <p class="text-caption text-grey-darken-1 mb-4">
+                  See the <a href="https://github.com/FreeCAD/Ondsel-Server/blob/main/docs/admin-panel.md#github-oauth" target="_blank" rel="noopener noreferrer">GitHub OAuth setup instructions</a> in the OAuth Configuration documentation. Use the Redirect URI shown below when configuring your GitHub OAuth app.
+                </p>
+
+                <v-switch
+                  v-model="githubConfig.enabled"
+                  label="Enable GitHub OAuth"
+                  color="primary"
+                ></v-switch>
+
+                <template v-if="!githubConfig.enabled">
+                  <p class="text-caption text-grey-darken-1 mb-4">
+                    Enable GitHub OAuth above to configure Client ID and Client Secret.
+                  </p>
+                </template>
+
+                <v-text-field
+                  v-model="githubConfig.clientId"
+                  label="Client ID"
+                  :rules="githubRules.clientId"
+                  :disabled="isSaving || !githubConfig.enabled"
+                  type="text"
+                  hint="GitHub OAuth App Client ID"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="githubConfig.clientSecret"
+                  label="Client Secret"
+                  :rules="githubRules.clientSecret"
+                  :disabled="isSaving || !githubConfig.enabled"
+                  type="password"
+                  hint="GitHub OAuth App Client Secret (masked for security)"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  :model-value="githubRedirectUri"
+                  label="Redirect URI"
+                  readonly
+                  hint="Use this redirect URI when configuring your GitHub OAuth app"
+                  persistent-hint
+                  class="mb-2"
+                >
+                  <template v-slot:append>
+                    <v-btn
+                      icon="mdi-content-copy"
+                      variant="text"
+                      size="small"
+                      @click="copyToClipboard(githubRedirectUri)"
+                    ></v-btn>
+                  </template>
+                </v-text-field>
+              </v-card-text>
+            </v-card>
+          </v-col>
         </v-row>
       </v-form>
     </v-card-text>
@@ -116,6 +178,11 @@ export default {
         clientId: '',
         clientSecret: '',
       },
+      githubConfig: {
+        enabled: false,
+        clientId: '',
+        clientSecret: '',
+      },
       showSnackbar: false,
       snackbarMessage: '',
       snackbarColor: 'success',
@@ -130,6 +197,20 @@ export default {
           v => {
             if (!this.googleConfig.enabled) return true;
             return !!v || 'Client Secret is required when Google OAuth is enabled';
+          }
+        ],
+      },
+      githubRules: {
+        clientId: [
+          v => {
+            if (!this.githubConfig.enabled) return true;
+            return !!v || 'Client ID is required when GitHub OAuth is enabled';
+          }
+        ],
+        clientSecret: [
+          v => {
+            if (!this.githubConfig.enabled) return true;
+            return !!v || 'Client Secret is required when GitHub OAuth is enabled';
           }
         ],
       },
@@ -150,16 +231,27 @@ export default {
       const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
       return `${baseUrl}/oauth/google/callback`;
     },
+    githubRedirectUri() {
+      const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
+      return `${baseUrl}/oauth/github/callback`;
+    },
   },
   watch: {
     'siteConfig': {
       handler(newVal) {
-        if (newVal && newVal.oauth?.providers?.google) {
-          if (!this.googleConfig.clientId) {
+        if (newVal && newVal.oauth?.providers) {
+          if (newVal.oauth.providers.google && !this.googleConfig.clientId) {
             this.googleConfig = {
               enabled: newVal.oauth.providers.google.enabled || false,
               clientId: newVal.oauth.providers.google.clientId || '',
               clientSecret: newVal.oauth.providers.google.clientSecret || '',
+            };
+          }
+          if (newVal.oauth.providers.github && !this.githubConfig.clientId) {
+            this.githubConfig = {
+              enabled: newVal.oauth.providers.github.enabled || false,
+              clientId: newVal.oauth.providers.github.clientId || '',
+              clientSecret: newVal.oauth.providers.github.clientSecret || '',
             };
           }
         }
@@ -167,6 +259,14 @@ export default {
       immediate: true
     },
     'googleConfig.enabled'() {
+      // Trigger validation when enabled state changes
+      this.$nextTick(() => {
+        if (this.$refs.form) {
+          this.$refs.form.validate();
+        }
+      });
+    },
+    'githubConfig.enabled'() {
       // Trigger validation when enabled state changes
       this.$nextTick(() => {
         if (this.$refs.form) {
@@ -191,6 +291,12 @@ export default {
               clientId: this.googleConfig.clientId.trim(),
               clientSecret: this.googleConfig.clientSecret.trim(),
               redirectUri: this.googleRedirectUri,
+            },
+            github: {
+              enabled: this.githubConfig.enabled,
+              clientId: this.githubConfig.clientId.trim(),
+              clientSecret: this.githubConfig.clientSecret.trim(),
+              redirectUri: this.githubRedirectUri,
             },
           }
         };


### PR DESCRIPTION
The goal of this PR is to allow users to log in using Github.

By default, Github OAuth is disabled. To enable it, log in as an admin user and open the [OAuth Xavier page](http://localhost:3000/xavier-oauth-12345678). Enter the Client ID and Client Secret there.

Detailed instructions for configuring Github OAuth are available here: [docs](https://github.com/FreeCAD/Ondsel-Server/blob/f3b674ef9c046e26af7bc93d2a7d50ae52784968/docs/admin-panel.md#oauth-configuration)

<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/f4a83655-f29f-48f5-965e-0a9b9f125d46" />

<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/c32482a8-7582-4ab3-bc19-1578c1c2ac0a" />

<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/3fd0f938-5296-47cb-b125-df3217ecfab8" />

