### PR TITLE
fix(site-config): prevent OAuth client secrets exposure in public API

### DIFF
--- a/backend/src/services/hooks/administration.js
+++ b/backend/src/services/hooks/administration.js
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Ondsel <development@ondsel.com>
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -43,4 +44,14 @@ export const verifySiteAdministrativePower = async context => {
     throw new NotAuthenticated(reason);
   }
   return context;
+}
+
+/**
+ * External resolver helper for admin-only fields
+ * Returns undefined for non-admin users, value for admins
+ */
+export const adminOnlyField = async (value, data, context) => {
+  if (!context.params.user) return undefined
+  const [isAdmin] = await isSiteAdministrator(context.params, context.app)
+  return isAdmin ? value : undefined
 }

--- a/backend/src/services/site-config/helpers.js
+++ b/backend/src/services/site-config/helpers.js
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export const OAUTH_SECRET_MASKED_VALUE = '***MASKED***'
+
+export const filterOAuthDataForAdmin = (oauthData) => {
+  if (!oauthData?.providers) return oauthData
+  const filteredProviders = {}
+  for (const [providerName, providerData] of Object.entries(oauthData.providers)) {
+    if (providerData) {
+      if (providerData.clientSecret) {
+        filteredProviders[providerName] = {
+          ...providerData,
+          clientSecret: OAUTH_SECRET_MASKED_VALUE
+        }
+      } else {
+        filteredProviders[providerName] = providerData
+      }
+    }
+  }
+  return {
+    providers: filteredProviders
+  }
+}
+
+export const filterOAuthDataForPublic = (oauthData) => {
+  if (!oauthData?.providers) return oauthData
+  return {
+    providers: {
+      google: oauthData.providers.google ? { enabled: oauthData.providers.google.enabled } : undefined,
+      github: oauthData.providers.github ? { enabled: oauthData.providers.github.enabled } : undefined
+    }
+  }
+}
+
+export const filterSiteConfigForPublic = (siteConfig) => {
+  if (!siteConfig) return siteConfig
+  return {
+    _id: siteConfig._id,
+    logoUrl: siteConfig.logoUrl,
+    faviconUrl: siteConfig.faviconUrl,
+    siteTitle: siteConfig.siteTitle,
+    socialLinks: siteConfig.socialLinks,
+    copyrightText: siteConfig.copyrightText,
+    homepageContent: siteConfig.homepageContent,
+    desktopApp: siteConfig.desktopApp,
+    oauth: filterOAuthDataForPublic(siteConfig.oauth),
+  }
+}
+
+export const filterMaskedOAuthSecretsFromPatch = (oauthData, existingOAuthData) => {
+  if (!oauthData?.providers) return oauthData
+
+  const filteredProviders = {}
+  for (const [providerName, providerData] of Object.entries(oauthData.providers)) {
+    if (providerData) {
+      const { clientSecret, ...rest } = providerData
+      if (clientSecret === OAUTH_SECRET_MASKED_VALUE) {
+        const existingProvider = existingOAuthData?.providers?.[providerName]
+        if (existingProvider?.clientSecret) {
+          filteredProviders[providerName] = {
+            ...rest,
+            clientSecret: existingProvider.clientSecret
+          }
+        } else {
+          filteredProviders[providerName] = rest
+        }
+      } else {
+        filteredProviders[providerName] = providerData
+      }
+    }
+  }
+
+  return {
+    providers: filteredProviders
+  }
+}

--- a/backend/src/services/site-config/site-config.js
+++ b/backend/src/services/site-config/site-config.js
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Ondsel <development@ondsel.com>
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -14,6 +15,7 @@ import {
   siteConfigResolver,
   siteConfigExternalResolver
 } from './site-config.schema.js'
+import { filterSiteConfigForPublic } from './helpers.js'
 import { SiteConfigService, getOptions } from './site-config.class.js'
 import { siteConfigPath, siteConfigMethods } from './site-config.shared.js'
 import { siteConfigId } from './site-config.schema.js'
@@ -100,9 +102,10 @@ export const siteConfig = (app) => {
   // Add publish configuration for real-time updates
   app.service(siteConfigPath).publish('patched', (data, context) => {
     // Broadcast site config updates to all users (public and authenticated)
+    const filteredData = filterSiteConfigForPublic(data)
     return [
-      app.channel('anonymous'),
-      app.channel('authenticated')
+      app.channel('anonymous').send(filteredData),
+      app.channel('authenticated').send(filteredData)
     ];
   });
 
@@ -110,6 +113,19 @@ export const siteConfig = (app) => {
   app.service(siteConfigPath).hooks({
     around: {
       all: [
+        // Authenticate before external resolver needs user
+        async (context, next) => {
+          if (context.method === 'get') {
+            // For non-default configs, require authentication
+            if (context.id !== siteConfigId) {
+              await authenticate('jwt')(context)
+            } else if (context.params.authentication) {
+              // For default config, authenticate if token provided (for admin access)
+              await authenticate('jwt')(context)
+            }
+          }
+          return next()
+        },
         schemaHooks.resolveExternal(siteConfigExternalResolver),
         schemaHooks.resolveResult(siteConfigResolver)
       ]
@@ -120,15 +136,8 @@ export const siteConfig = (app) => {
         schemaHooks.resolveQuery(siteConfigQueryResolver)
       ],
       get: [
-        // Allow public access to default site config
-        async (context) => {
-          if (context.id === siteConfigId) {
-            return context; // Skip authentication
-          }
-          // Require authentication for other configs
-          return authenticate('jwt')(context);
-        },
-        // Only verify admin power for non-default configs
+        // Verify admin power for non-default configs
+        // (Authentication already handled in around.all hook)
         async (context) => {
           if (context.id !== siteConfigId) {
             return verifySiteAdministrativePower(context);

--- a/backend/src/services/site-config/site-config.schema.js
+++ b/backend/src/services/site-config/site-config.schema.js
@@ -7,7 +7,9 @@ import { resolve, virtual } from '@feathersjs/schema'
 import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import { ObjectIdSchema } from '@feathersjs/typebox'
 import { dataValidator, queryValidator } from '../../validators.js'
-import { userSummarySchema } from '../users/users.subdocs.schema.js';
+import { userSummarySchema } from '../users/users.subdocs.schema.js'
+import { isSiteAdministrator, adminOnlyField } from '../hooks/administration.js'
+import { filterOAuthDataForPublic, filterOAuthDataForAdmin, filterMaskedOAuthSecretsFromPatch } from './helpers.js'
 
 // Fixed ID for the single site config document
 export const siteConfigId = '000000000000000000000000';
@@ -113,7 +115,18 @@ export const siteConfigResolver = resolve({
   }),
 })
 
-export const siteConfigExternalResolver = resolve({})
+export const siteConfigExternalResolver = resolve({
+  oauth: async (value, data, context) => {
+    if (!context.params.user) return filterOAuthDataForPublic(value)
+    const [isAdmin] = await isSiteAdministrator(context.params, context.app)
+    return isAdmin ? filterOAuthDataForAdmin(value) : filterOAuthDataForPublic(value)
+  },
+  defaultModel: adminOnlyField,
+  defaultModelObjUrl: adminOnlyField,
+  customized: adminOnlyField,
+  updatedAt: adminOnlyField,
+  updatedBy: adminOnlyField
+})
 
 // Schema for updating existing entries
 export const siteConfigPatchSchema = Type.Partial(siteConfigSchema, {
@@ -131,6 +144,17 @@ export const siteConfigPatchResolver = resolve({
       }
     }
     return _value
+  },
+  oauth: async (value, _message, context) => {
+    if (value) {
+      try {
+        const existingConfig = await context.app.service('site-config').get(context.id)
+        return filterMaskedOAuthSecretsFromPatch(value, existingConfig?.oauth)
+      } catch (error) {
+        return filterMaskedOAuthSecretsFromPatch(value, null)
+      }
+    }
+    return value
   }
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2024 Ondsel <development@ondsel.com>
+SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -17,13 +18,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <script>
 import MainNavigationBar from '@/layouts/default/MainNavigationBar.vue';
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 
 export default {
   name: 'App',
   components: { MainNavigationBar },
   computed: {
     ...mapGetters('app', ['siteConfig']),
+    ...mapState('auth', ['user']),
   },
   data: () => ({
   }),
@@ -41,6 +43,13 @@ export default {
         }
       },
       immediate: true
+    },
+    'user': {
+      handler(newUser) {
+        if (newUser) {
+          this.loadSiteConfig();
+        }
+      }
     }
   },
   methods: {

--- a/frontend/src/views/XavierOAuthConfig.vue
+++ b/frontend/src/views/XavierOAuthConfig.vue
@@ -256,7 +256,8 @@ export default {
           }
         }
       },
-      immediate: true
+      immediate: true,
+      deep: true
     },
     'googleConfig.enabled'() {
       // Trigger validation when enabled state changes


### PR DESCRIPTION
## Tasks

- Filter OAuth data to only show 'enabled' for public users, full data for admins
- Add admin-only field filtering via external resolver
- Filter real-time events to prevent sensitive data leaks
- Fix frontend to refetch config on authentication