### PR TITLE
feat(oauth): add OpenID Connect (OIDC) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ docker-compose -f docker-compose.dev.yml --profile matomo-enabled up --build -d
 
 # To use prebuild docker images
 docker-compose -f docker-compose.prebuilds.yml --profile matomo-enabled up --build -d
+
+# With Keycloak (local OIDC for testing):
+docker-compose -f docker-compose.dev.yml --profile keycloak up --build -d
+
+# Seed OIDC site-config to point at the local Keycloak (one-time, idempotent):
+docker-compose -f docker-compose.dev.yml exec backend npm run migration seedDevKeycloakOidcSiteConfig
+
+# Restart backend so the new OIDC config is picked up:
+docker-compose -f docker-compose.dev.yml restart backend
 ```
 
 That's it! The application should now be running at http://localhost:3000
@@ -72,6 +81,13 @@ That's it! The application should now be running at http://localhost:3000
 - URL: http://localhost:3000
 - Email: admin@local.test
 - Password: admin@local.test
+
+##### Keycloak (local OIDC)
+- URL: http://localhost:8090
+- Admin username: admin
+- Admin password: admin@local.test
+- Test user email: admin@local.test
+- Test user password: admin@local.test
 
 These credentials can be customized using environment variables in the `.env` file.
 

--- a/backend/entry.sh
+++ b/backend/entry.sh
@@ -8,6 +8,7 @@
 npm run migration addInitialTosPp
 npm run migration createDefaultSiteConfig
 npm run migration addOauthToSiteConfig
+npm run migration addOidcProviderToSiteConfig
 npm run migration addDefaultAdminUser
 npm run migration createDefaultPublisherEntries
 

--- a/backend/src/authentication.js
+++ b/backend/src/authentication.js
@@ -8,7 +8,7 @@ import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication'
 import { LocalStrategy } from '@feathersjs/authentication-local'
 import { oauth } from '@feathersjs/authentication-oauth'
 import { NotFound } from '@feathersjs/errors'
-import { GitHubStrategy, GoogleStrategy } from './authentication/oauth-helper.js'
+import { GitHubStrategy, GoogleStrategy, OidcStrategy } from './authentication/oauth-helper.js'
 import { createRequire } from 'module'
 
 const require = createRequire(import.meta.url)
@@ -91,7 +91,7 @@ async function configureOAuth(app, authentication) {
   // Load OAuth config from site-config
   try {
     const siteConfig = await app.service('site-config').get(siteConfigId)
-    updateOAuthProviderConfigs(app, siteConfig)
+    await updateOAuthProviderConfigs(app, siteConfig)
   } catch (error) {
     if (error.code === 404 || error.className === 'not-found') {
       console.log('Site-config not found - OAuth will be available after migrations run')
@@ -105,7 +105,8 @@ async function configureOAuth(app, authentication) {
   // Build OAuth config for Grant
   const oauthConfig = {
     ...(providerConfigs.google ? { google: { ...providerConfigs.google } } : {}),
-    ...(providerConfigs.github ? { github: { ...providerConfigs.github } } : {})
+    ...(providerConfigs.github ? { github: { ...providerConfigs.github } } : {}),
+    ...(providerConfigs.oidc ? { oidc: { ...providerConfigs.oidc } } : {})
   }
 
   const currentAuthConfig = app.get('authentication') || {}
@@ -113,6 +114,7 @@ async function configureOAuth(app, authentication) {
 
   authentication.register('google', new GoogleStrategy())
   authentication.register('github', new GitHubStrategy())
+  authentication.register('oidc', new OidcStrategy())
   app.configure(oauth())
 
   // Patch OAuthService handler to support dynamic config updates
@@ -141,15 +143,15 @@ async function configureOAuth(app, authentication) {
   }
 
   // Store update function for site-config service hook
-  app.set('updateOAuthConfig', (siteConfig) => {
-    updateOAuthProviderConfigs(app, siteConfig)
+  app.set('updateOAuthConfig', async (siteConfig) => {
+    await updateOAuthProviderConfigs(app, siteConfig)
   })
 }
 
 /**
  * Update OAuth provider configs from site-config
  */
-function updateOAuthProviderConfigs(app, siteConfig) {
+async function updateOAuthProviderConfigs(app, siteConfig) {
   const providerConfigs = {}
 
   const googleConfig = siteConfig?.oauth?.providers?.google
@@ -176,6 +178,32 @@ function updateOAuthProviderConfigs(app, siteConfig) {
       transport: 'state',
       response: ['tokens', 'raw', 'profile'],
       redirect_uri: githubConfig.redirectUri
+    }
+  }
+
+  const oidcConfig = siteConfig?.oauth?.providers?.oidc
+  if (
+    oidcConfig?.enabled &&
+    oidcConfig.clientId &&
+    oidcConfig.clientSecret &&
+    oidcConfig.redirectUri &&
+    oidcConfig.authorizeUrl &&
+    oidcConfig.tokenUrl &&
+    oidcConfig.userinfoUrl
+  ) {
+    providerConfigs.oidc = {
+      authorize_url: oidcConfig.authorizeUrl,
+      access_url: oidcConfig.tokenUrl,
+      profile_url: oidcConfig.userinfoUrl,
+      oauth: 2,
+      key: oidcConfig.clientId,
+      secret: oidcConfig.clientSecret,
+      scope: 'openid email profile',
+      nonce: true,
+      transport: 'state',
+      response: ['tokens', 'raw', 'profile'],
+      redirect_uri: oidcConfig.redirectUri,
+      scope_delimiter: ' '
     }
   }
 

--- a/backend/src/authentication/oauth-helper.js
+++ b/backend/src/authentication/oauth-helper.js
@@ -294,3 +294,46 @@ export class GitHubStrategy extends BaseOAuthStrategy {
     }
   }
 }
+
+/**
+ * OIDC OAuth strategy
+ */
+export class OidcStrategy extends BaseOAuthStrategy {
+  /**
+   * Fetch user profile from the OIDC userinfo endpoint
+   */
+  async getProfile(data, params) {
+    const userinfoUrl = this.configuration.profile_url
+    if (!userinfoUrl) {
+      throw new Error('OIDC userinfo URL is not configured')
+    }
+
+    const response = await fetch(userinfoUrl, {
+      headers: {
+        Authorization: `Bearer ${data.access_token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch OIDC userinfo')
+    }
+
+    const profile = await response.json()
+
+    if (!profile.email) {
+      throw new Error('Email is required but not provided by OIDC userinfo')
+    }
+
+    const id = profile.sub != null ? String(profile.sub) : (profile.id != null ? String(profile.id) : '')
+    if (!id) {
+      throw new Error('OIDC userinfo must include sub')
+    }
+
+    return {
+      id,
+      email: profile.email,
+      name: profile.name ?? profile.preferred_username ?? profile.email.split('@')[0],
+      suggestedUsername: profile.preferred_username ?? this.generateUsernameFromEmail(profile.email)
+    }
+  }
+}

--- a/backend/src/authentication/oidc-discovery.js
+++ b/backend/src/authentication/oidc-discovery.js
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export function normalizeOidcIssuer(issuer) {
+  if (!issuer || typeof issuer !== 'string') return ''
+  return issuer.trim().replace(/\/+$/, '')
+}
+
+export async function fetchOpenIdConfiguration(issuer) {
+  const base = normalizeOidcIssuer(issuer)
+  if (!base) {
+    throw new Error('Issuer is required')
+  }
+  const discoveryUrl = `${base}/.well-known/openid-configuration`
+  const res = await fetch(discoveryUrl, {
+    headers: { Accept: 'application/json' }
+  })
+  if (!res.ok) {
+    throw new Error(`OIDC discovery request failed: ${res.status}`)
+  }
+  const doc = await res.json()
+  const authorization_endpoint = doc.authorization_endpoint
+  const token_endpoint = doc.token_endpoint
+  const userinfo_endpoint = doc.userinfo_endpoint
+  if (!authorization_endpoint || !token_endpoint || !userinfo_endpoint) {
+    throw new Error('OIDC discovery document is missing required endpoints')
+  }
+  return {
+    authorization_endpoint,
+    token_endpoint,
+    userinfo_endpoint
+  }
+}

--- a/backend/src/migrations/add-oidc-provider-to-site-config.command.js
+++ b/backend/src/migrations/add-oidc-provider-to-site-config.command.js
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { ObjectId } from 'mongodb'
+import { siteConfigId } from '../services/site-config/site-config.schema.js'
+
+const defaultOidcProvider = {
+  enabled: false,
+  clientId: '',
+  clientSecret: '',
+  redirectUri: '',
+  issuer: '',
+  authorizeUrl: '',
+  tokenUrl: '',
+  userinfoUrl: '',
+  signInWithName: '',
+}
+
+export async function addOidcProviderToSiteConfigCommand(app) {
+  console.log('>>> checking for site config (add oidc provider)')
+  const db = await app.get('mongodbClient')
+  const collection = db.collection('site-config')
+
+  const existingConfig = await collection.findOne({ _id: new ObjectId(siteConfigId) })
+
+  if (!existingConfig) {
+    console.log('>>> site config does not exist, skipping migration')
+    return
+  }
+
+  if (!existingConfig.oauth?.providers) {
+    console.log('>>> site config has no oauth.providers, skipping migration')
+    return
+  }
+
+  if (existingConfig.oauth.providers.oidc) {
+    console.log('>>> site config already has oauth.providers.oidc, skipping migration')
+    return
+  }
+
+  console.log('>>> adding oauth.providers.oidc to site config')
+
+  await collection.updateOne(
+    { _id: new ObjectId(siteConfigId) },
+    {
+      $set: {
+        'oauth.providers.oidc': { ...defaultOidcProvider },
+      },
+    }
+  )
+
+  console.log('>>> oauth.providers.oidc added to site config')
+}

--- a/backend/src/migrations/create-default-site-config.command.js
+++ b/backend/src/migrations/create-default-site-config.command.js
@@ -101,6 +101,17 @@ export async function createDefaultSiteConfigCommand(app) {
           clientSecret: '',
           redirectUri: '',
         },
+        oidc: {
+          enabled: false,
+          clientId: '',
+          clientSecret: '',
+          redirectUri: '',
+          issuer: '',
+          authorizeUrl: '',
+          tokenUrl: '',
+          userinfoUrl: '',
+          signInWithName: '',
+        },
       }
     },
     customized: {

--- a/backend/src/migrations/run-migration.js
+++ b/backend/src/migrations/run-migration.js
@@ -51,6 +51,7 @@ import {addDefaultAdminUserCommand} from "./create-default-admin-user.command.js
 import {createDefaultSiteConfigCommand} from "./create-default-site-config.command.js";
 import {addOauthToSiteConfigCommand} from "./add-oauth-to-site-config.command.js";
 import { addOidcProviderToSiteConfigCommand } from './add-oidc-provider-to-site-config.command.js';
+import { seedDevKeycloakOidcSiteConfigCommand } from './seed-dev-keycloak-oidc-site-config.command.js';
 import {createDefaultPublisherEntriesCommand} from "./create-default-publisher-entries.command.js";
 import {migrateOndselToAdminOrganizationCommand} from "./migrate-ondsel-to-admin-organization.command.js";
 
@@ -208,6 +209,9 @@ async function runMigration() {
       break;
     case 'addOidcProviderToSiteConfig':
       await addOidcProviderToSiteConfigCommand(app);
+      break;
+    case 'seedDevKeycloakOidcSiteConfig':
+      await seedDevKeycloakOidcSiteConfigCommand(app);
       break;
     case 'createDefaultPublisherEntries':
       await createDefaultPublisherEntriesCommand(app);

--- a/backend/src/migrations/run-migration.js
+++ b/backend/src/migrations/run-migration.js
@@ -50,6 +50,7 @@ import {fixedSharedWithMeSchemasCommand} from "./fixed-shared-with-me-schemas.co
 import {addDefaultAdminUserCommand} from "./create-default-admin-user.command.js";
 import {createDefaultSiteConfigCommand} from "./create-default-site-config.command.js";
 import {addOauthToSiteConfigCommand} from "./add-oauth-to-site-config.command.js";
+import { addOidcProviderToSiteConfigCommand } from './add-oidc-provider-to-site-config.command.js';
 import {createDefaultPublisherEntriesCommand} from "./create-default-publisher-entries.command.js";
 import {migrateOndselToAdminOrganizationCommand} from "./migrate-ondsel-to-admin-organization.command.js";
 
@@ -204,6 +205,9 @@ async function runMigration() {
       break;
     case 'addOauthToSiteConfig':
       await addOauthToSiteConfigCommand(app);
+      break;
+    case 'addOidcProviderToSiteConfig':
+      await addOidcProviderToSiteConfigCommand(app);
       break;
     case 'createDefaultPublisherEntries':
       await createDefaultPublisherEntriesCommand(app);

--- a/backend/src/migrations/seed-dev-keycloak-oidc-site-config.command.js
+++ b/backend/src/migrations/seed-dev-keycloak-oidc-site-config.command.js
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Amritpal Singh <amrit3701@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { ObjectId } from 'mongodb'
+import { siteConfigId } from '../services/site-config/site-config.schema.js'
+
+export async function seedDevKeycloakOidcSiteConfigCommand(app) {
+  const keycloakPort = process.env.KEYCLOAK_PORT || '8090'
+  const backendPort = process.env.PORT || '3030'
+  const realm = process.env.KEYCLOAK_REALM || 'lens'
+  const clientId = process.env.OIDC_CLIENT_ID || 'lens-backend'
+  const clientSecret = process.env.OIDC_CLIENT_SECRET || 'lens-backend-secret'
+  const publicHost = process.env.KEYCLOAK_PUBLIC_HOST || 'localhost'
+  const internalBase = process.env.KEYCLOAK_INTERNAL_BASE || 'http://keycloak:8080'
+
+  const issuerPublic = `http://${publicHost}:${keycloakPort}/realms/${realm}`
+  const authorizeUrl = `${issuerPublic}/protocol/openid-connect/auth`
+  const internalConnect = `${internalBase.replace(/\/+$/, '')}/realms/${realm}/protocol/openid-connect`
+  const tokenUrl = `${internalConnect}/token`
+  const userinfoUrl = `${internalConnect}/userinfo`
+  const redirectUri = `http://${publicHost}:${backendPort}/oauth/oidc/callback`
+
+  const oidc = {
+    enabled: true,
+    clientId,
+    clientSecret,
+    redirectUri,
+    issuer: issuerPublic,
+    authorizeUrl,
+    tokenUrl,
+    userinfoUrl,
+    signInWithName: '',
+  }
+
+  console.log('>>> seed dev keycloak oidc site-config')
+
+  const db = await app.get('mongodbClient')
+  const collection = db.collection('site-config')
+  const id = new ObjectId(siteConfigId)
+
+  const doc = await collection.findOne({ _id: id })
+  if (!doc) {
+    console.log('>>> site config does not exist, skipping')
+    return
+  }
+
+  const existingIssuer = typeof doc.oauth?.providers?.oidc?.issuer === 'string' ? doc.oauth.providers.oidc.issuer.trim() : ''
+  if (existingIssuer) {
+    console.log('>>> skipping: oauth.providers.oidc.issuer already set')
+    return
+  }
+
+  await collection.updateOne(
+    { _id: id },
+    {
+      $set: {
+        'oauth.providers.oidc': oidc,
+        updatedAt: Date.now(),
+      },
+    }
+  )
+
+  console.log('>>> oauth.providers.oidc updated')
+
+  const updateOAuthConfig = app.get('updateOAuthConfig')
+  if (typeof updateOAuthConfig === 'function') {
+    try {
+      const full = await collection.findOne({ _id: id })
+      await updateOAuthConfig(full)
+      console.log('>>> oauth grant config reloaded')
+    } catch (e) {
+      console.log('>>> oauth reload failed:', e.message)
+    }
+  }
+}

--- a/backend/src/services/site-config/helpers.js
+++ b/backend/src/services/site-config/helpers.js
@@ -29,7 +29,8 @@ export const filterOAuthDataForPublic = (oauthData) => {
   return {
     providers: {
       google: oauthData.providers.google ? { enabled: oauthData.providers.google.enabled } : undefined,
-      github: oauthData.providers.github ? { enabled: oauthData.providers.github.enabled } : undefined
+      github: oauthData.providers.github ? { enabled: oauthData.providers.github.enabled } : undefined,
+      oidc: oauthData.providers.oidc ? { enabled: oauthData.providers.oidc.enabled, signInWithName: oauthData.providers.oidc.signInWithName } : undefined
     }
   }
 }

--- a/backend/src/services/site-config/site-config.js
+++ b/backend/src/services/site-config/site-config.js
@@ -5,6 +5,7 @@
 
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.html
 import { authenticate } from '@feathersjs/authentication'
+import { authenticate as expressAuthenticate } from '@feathersjs/express'
 import { hooks as schemaHooks } from '@feathersjs/schema'
 import { disallow } from 'feathers-hooks-common'
 import swagger from 'feathers-swagger'
@@ -23,12 +24,13 @@ import { filterSiteConfigForPublic } from './helpers.js'
 import { SiteConfigService, getOptions } from './site-config.class.js'
 import { siteConfigPath, siteConfigMethods } from './site-config.shared.js'
 import { siteConfigId } from './site-config.schema.js'
-import { verifySiteAdministrativePower } from '../hooks/administration.js'
+import { verifySiteAdministrativePower, isSiteAdministrator } from '../hooks/administration.js'
 import { setCustomizedFlags } from './set-customized-flags.hook.js'
 import { uploadBrandingLogo } from './upload-branding.hook.js'
 import { uploadDefaultModel, uploadDefaultModelThumbnail } from './upload-default-model.hook.js'
 import { parseSocialLinks } from './parse-social-links.hook.js'
 import multer from 'multer'
+import { fetchOpenIdConfiguration } from '../../authentication/oidc-discovery.js'
 
 export * from './site-config.class.js'
 export * from './site-config.schema.js'
@@ -291,4 +293,44 @@ export const siteConfig = (app) => {
       return res.status(500).json({ error: 'Failed to fetch FreeCAD feed', details: error.message });
     }
   });
+
+  // Resolve OIDC endpoint URLs from an issuer (OAuth settings screen)
+  app.post(
+    '/oidc-discovery',
+    (req, res, next) => {
+      expressAuthenticate('jwt')(req, res, (err) => {
+        if (err) {
+          return res.status(401).json({ error: 'Not authenticated' })
+        }
+        next()
+      })
+    },
+    async (req, res) => {
+      try {
+        const user = req.feathers?.user
+        if (!user) {
+          return res.status(401).json({ error: 'Not authenticated' })
+        }
+        const [isAdmin, reason] = await isSiteAdministrator(
+          { user, provider: 'rest' },
+          app
+        )
+        if (!isAdmin) {
+          return res.status(403).json({ error: reason || 'Forbidden' })
+        }
+        const issuer = typeof req.body?.issuer === 'string' ? req.body.issuer.trim() : ''
+        if (!issuer) {
+          return res.status(400).json({ error: 'issuer is required' })
+        }
+        const doc = await fetchOpenIdConfiguration(issuer)
+        return res.json({
+          authorizeUrl: doc.authorization_endpoint,
+          tokenUrl: doc.token_endpoint,
+          userinfoUrl: doc.userinfo_endpoint
+        })
+      } catch (e) {
+        return res.status(400).json({ error: e.message || 'OIDC discovery failed' })
+      }
+    }
+  );
 }

--- a/backend/src/services/site-config/site-config.schema.js
+++ b/backend/src/services/site-config/site-config.schema.js
@@ -64,11 +64,25 @@ const oauthProviderConfigSchema = Type.Object({
   redirectUri: Type.String(),
 })
 
+// OIDC provider config sub-schema
+const oauthOidcProviderConfigSchema = Type.Object({
+  enabled: Type.Boolean(),
+  clientId: Type.String(),
+  clientSecret: Type.String(),
+  redirectUri: Type.String(),
+  issuer: Type.String(),
+  authorizeUrl: Type.String(),
+  tokenUrl: Type.String(),
+  userinfoUrl: Type.String(),
+  signInWithName: Type.String({ maxLength: 20 }),
+})
+
 // OAuth config sub-schema
 const oauthConfigSchema = Type.Object({
   providers: Type.Object({
     google: oauthProviderConfigSchema,
     github: oauthProviderConfigSchema,
+    oidc: oauthOidcProviderConfigSchema,
   })
 })
 

--- a/backend/src/services/users/users.schema.js
+++ b/backend/src/services/users/users.schema.js
@@ -46,6 +46,9 @@ export const userSchema = Type.Object(
       github: Type.Optional(Type.Object({
         id: Type.String(),
       })),
+      oidc: Type.Optional(Type.Object({
+        id: Type.String(),
+      })),
     })),
     name: Type.String(),
     firstName: Type.String(), // deprecated
@@ -197,6 +200,7 @@ export const userQuerySchema = Type.Intersect(
       'getOnlyAccessTokenUser': Type.Optional(Type.String()),
       'oauthProviders.google.id': Type.Optional(Type.String()),
       'oauthProviders.github.id': Type.Optional(Type.String()),
+      'oauthProviders.oidc.id': Type.Optional(Type.String()),
     }, { additionalProperties: false })
   ],
   { additionalProperties: false }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -137,6 +137,25 @@ services:
     depends_on:
       - matomo-db
 
+  # Keycloak for local OIDC (profile keycloak; realm under docker/keycloak/import)
+  keycloak:
+    profiles:
+      - keycloak
+    image: quay.io/keycloak/keycloak:26.6.1
+    command:
+      - start-dev
+      - --import-realm
+    ports:
+      - "${KEYCLOAK_PORT:-8090}:8080"
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin@local.test}
+      KC_HOSTNAME: http://localhost:${KEYCLOAK_PORT:-8090}
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+    volumes:
+      - keycloak_dev_data:/opt/keycloak/data
+      - ./docker/keycloak/import:/opt/keycloak/data/import
+
 volumes:
   mongodb_data:
     name: mongodb_data_dev
@@ -146,3 +165,5 @@ volumes:
     name: matomo_db_dev
   matomo_data:
     name: matomo_data_dev
+  keycloak_dev_data:
+    name: keycloak_dev_data_dev

--- a/docker/keycloak/import/lens-realm.json
+++ b/docker/keycloak/import/lens-realm.json
@@ -1,0 +1,52 @@
+{
+  "realm": "lens",
+  "enabled": true,
+  "displayName": "Lens",
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "clients": [
+    {
+      "clientId": "lens-backend",
+      "name": "Lens backend OIDC",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "lens-backend-secret",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:3030/oauth/oidc/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:3030"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "admin@local.test",
+      "email": "admin@local.test",
+      "firstName": "Lens",
+      "lastName": "Admin",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin@local.test",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -29,7 +29,7 @@ The Xavier admin panel is a hidden administrative interface for site administrat
 | [Brand Identity](#brand-identity) | `/xavier-branding-logo-87654321` | Logo, favicon, title & social links |
 | [Homepage Content](#homepage-content) | `/xavier-branding-homepage-11223344` | Homepage customization |
 | [Default Model](#default-model) | `/xavier-branding-default-model-55667788` | Default 3D model for new users |
-| [OAuth Configuration](#oauth-configuration) | `/xavier-oauth-12345678` | OAuth provider configuration (Google, GitHub) |
+| [OAuth Configuration](#oauth-configuration) | `/xavier-oauth-12345678` | OAuth provider configuration (Google, GitHub, OIDC) |
 | [Software Releases](#software-releases) | `/xavier-9384242` | Manage download links |
 | [Key Documents](#key-documents) | `/xavier-7492783/:name` | Legal document management |
 | [Remove User](#remove-user) | `/xavier-55554337898` | User account deletion |
@@ -146,7 +146,7 @@ Upload and configure the default 3D model that appears for new user registration
 
 **Route:** `/xavier-oauth-12345678`
 
-Configure OAuth 2.0 authentication providers to enable social login for users. Currently supports Google and GitHub OAuth.
+Configure OAuth 2.0 / OpenID Connect authentication providers to enable social login for users. Supports Google, GitHub, and generic OIDC (for example Keycloak).
 
 ### Configurable Options
 
@@ -166,6 +166,21 @@ Configure OAuth 2.0 authentication providers to enable social login for users. C
 | Client Secret | GitHub OAuth App Client Secret (masked input) |
 | Redirect URI | Auto-generated redirect URI (read-only, copy to GitHub OAuth App settings) |
 
+#### OpenID Connect (OIDC)
+
+| Setting | Description |
+|---------|-------------|
+| Enable OIDC sign-in | Toggle to enable/disable SSO login via your OIDC IdP |
+| Issuer URL | OIDC issuer identifier (must match your IdP). Example: `https://auth.example.com/realms/myrealm`. Required for **Fetch endpoints from issuer**; the server must be able to reach this URL when you click that button |
+| Client ID | OIDC client ID from your identity provider |
+| Client Secret | OIDC client secret (masked input) |
+| Sign-in button suffix | Text shown after **Sign in with** on login and sign-up (for example `Keycloak` → **Sign in with Keycloak**). Leave empty to use **SSO** |
+| Fetch endpoints from issuer | Looks up your IdP’s discovery document from the **Issuer URL** and fills in the three endpoint fields below |
+| Authorization endpoint URL | Paste from your IdP or use **Fetch endpoints from issuer** |
+| Token endpoint URL | Paste the token endpoint from your IdP or use **Fetch endpoints from issuer** |
+| Userinfo endpoint URL | Paste the userinfo endpoint from your IdP or use **Fetch endpoints from issuer** |
+| Redirect URI | Auto-generated redirect URI (read-only, register this exact URL as an allowed redirect in your IdP client) |
+
 ### Usage
 
 1. **For Google OAuth:**
@@ -183,12 +198,25 @@ Configure OAuth 2.0 authentication providers to enable social login for users. C
    - Enter Client ID and Client Secret
    - Click **Save** to apply changes
 
+3. **For OpenID Connect (OIDC):**
+   - In your IdP, create an OIDC client following your identity provider’s documentation
+   - Set the client redirect URI to match the displayed Redirect URI
+   - In the IdP, allow the scopes Lens uses at login: **`openid`**, **`email`**, and **`profile`**
+   - If the Lens **server** cannot reach your issuer hostname from its network (for example in Docker), use an **Issuer URL** the server can resolve and reach (not only a URL that works in the browser)
+   - Enable **OIDC sign-in** toggle
+   - Enter **Issuer URL**, **Client ID**, and **Client Secret**
+   - Optionally set **Sign-in button suffix** so the OIDC button matches your IdP name (or leave empty for **Sign in with SSO**)
+   - Enter **Authorization**, **Token**, and **Userinfo** endpoint URLs (paste from your IdP, or click **Fetch endpoints from issuer** after filling the issuer)
+   - Click **Save** to apply changes
+
 ### Features
-- Enable/disable toggles for each OAuth provider (Google, GitHub)
+- Enable/disable toggles for each OAuth provider (Google, GitHub, OIDC)
 - Secure credential storage (secrets are masked)
 - Auto-generated redirect URIs for each provider
+- OIDC: **Fetch endpoints from issuer** calls discovery and fills authorization, token, and userinfo URL fields (or paste those URLs manually)
 - "Sign in with Google" button appears on login page when Google OAuth enabled
 - "Sign in with GitHub" button appears on login page when GitHub OAuth enabled
+- **Sign in with …** OIDC button appears on login and sign-up when OIDC is enabled; the suffix is configurable (default **SSO**)
 
 ### Security Notes
 - OAuth credentials are stored securely in the site-config service

--- a/env.example
+++ b/env.example
@@ -65,3 +65,11 @@ MATOMO_USERNAME=
 MATOMO_PASSWORD=
 # Matomo email (default: admin@local.test)
 MATOMO_EMAIL=
+
+#########################
+######## Keycloak ########
+#########################
+# docker-compose.dev.yml profile keycloak
+KEYCLOAK_PORT=8090
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin@local.test

--- a/frontend/src/store/services/site-config.js
+++ b/frontend/src/store/services/site-config.js
@@ -92,6 +92,23 @@ class SiteConfig extends BaseModel {
             clientSecret: '',
             redirectUri: '',
           },
+          github: {
+            enabled: false,
+            clientId: '',
+            clientSecret: '',
+            redirectUri: '',
+          },
+          oidc: {
+            enabled: false,
+            clientId: '',
+            clientSecret: '',
+            redirectUri: '',
+            issuer: '',
+            authorizeUrl: '',
+            tokenUrl: '',
+            userinfoUrl: '',
+            signInWithName: '',
+          },
         }
       },
       customized: {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         </v-card>
         <p></p>
         <v-card :title="`Login to ${siteConfig?.siteTitle}`" width="26em" class="pa-2 mt-16">
-          <v-card-text :class="{ 'pb-6': !(isGoogleOAuthEnabled || isGitHubOAuthEnabled) }">
+          <v-card-text :class="{ 'pb-6': !isAnyOAuthEnabled }">
             <template v-slot:loader="{ isActive }">
               <v-progress-linear
                 :active="isAuthenticatePending"
@@ -73,7 +73,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 >Submit</v-btn>
               </v-row>
 
-              <v-row v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="mt-4">
+              <v-row v-if="isAnyOAuthEnabled" class="mt-4">
                 <v-col cols="12">
                   <div class="d-flex align-center my-2">
                     <v-divider></v-divider>
@@ -82,60 +82,89 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                   </div>
                 </v-col>
               </v-row>
-              <div v-if="isOAuthRedirecting && (isGoogleOAuthEnabled || isGitHubOAuthEnabled)" class="d-flex flex-column align-center justify-center mt-4" style="min-height: 40px;">
+              <div v-if="isOAuthRedirecting && isAnyOAuthEnabled" class="d-flex flex-column align-center justify-center mt-4" style="min-height: 40px;">
                 <v-progress-circular
                   indeterminate
                   color="primary"
                   size="40"
                   width="4"
                 ></v-progress-circular>
-                <span class="mt-2 text-caption text-grey">Redirecting to {{ oAuthRedirectingProvider === 'google' ? 'Google' : 'GitHub' }}...</span>
+                <span class="mt-2 text-caption text-grey">Redirecting to {{ oauthRedirectLabel }}...</span>
               </div>
-              <v-row v-else-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled">
-                <v-col v-if="isGoogleOAuthEnabled" cols="12" class="text-center" style="position: relative;">
-                  <img 
-                    src="/img/google-signin-button.svg" 
-                    alt="Sign in with Google"
-                    @click="!isAuthenticatePending && loginWithOAuth('google')"
-                    :style="{ 
-                      height: '40px', 
-                      width: 'auto', 
-                      cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
-                      opacity: isAuthenticatePending ? 0.6 : 1,
-                      display: 'block',
-                      margin: '0 auto'
-                    }"
-                    class="google-signin-button"
-                  />
-                </v-col>
-                <v-col v-if="isGitHubOAuthEnabled" cols="12" class="text-center" style="position: relative;">
-                  <v-btn
-                    variant="outlined"
-                    size="large"
-                    :disabled="isAuthenticatePending"
-                    @click="!isAuthenticatePending && loginWithOAuth('github')"
-                    :style="{ 
-                      height: '40px',
-                      width: 'auto',
-                      cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
-                      opacity: isAuthenticatePending ? 0.6 : 1,
-                      display: 'inline-flex',
-                      backgroundColor: '#FFFFFF',
-                      borderColor: '#747775',
-                      borderWidth: '1px',
-                      borderStyle: 'solid',
-                      color: '#3c4043 !important',
-                      textTransform: 'none',
-                      fontSize: '14px',
-                      fontWeight: '500',
-                      letterSpacing: '0.25px',
-                      padding: '0 16px'
-                    }"
-                    class="github-signin-button"
-                  >
-                    <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
-                    <span style="color: #3c4043;">Sign in with GitHub</span>
-                  </v-btn>
+              <v-row v-else-if="isAnyOAuthEnabled">
+                <v-col cols="12">
+                  <div class="oauth-provider-buttons">
+                    <div v-if="isGoogleOAuthEnabled" class="oauth-provider-buttons__cell">
+                      <img
+                        src="/img/google-signin-button.svg"
+                        alt="Sign in with Google"
+                        @click="!isAuthenticatePending && loginWithOAuth('google')"
+                        :style="{
+                          height: '40px',
+                          width: 'auto',
+                          maxWidth: '100%',
+                          cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
+                          opacity: isAuthenticatePending ? 0.6 : 1,
+                          display: 'block',
+                          margin: '0 auto'
+                        }"
+                        class="google-signin-button"
+                      />
+                    </div>
+                    <div v-if="isGitHubOAuthEnabled" class="oauth-provider-buttons__cell">
+                      <v-btn
+                        variant="outlined"
+                        size="large"
+                        :disabled="isAuthenticatePending"
+                        @click="!isAuthenticatePending && loginWithOAuth('github')"
+                        :style="{
+                          height: '40px',
+                          width: 'auto',
+                          maxWidth: '100%',
+                          cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
+                          opacity: isAuthenticatePending ? 0.6 : 1,
+                          display: 'inline-flex',
+                          backgroundColor: '#FFFFFF',
+                          borderColor: '#747775',
+                          borderWidth: '1px',
+                          borderStyle: 'solid',
+                          color: '#3c4043 !important',
+                          textTransform: 'none',
+                          fontSize: '14px',
+                          fontWeight: '500',
+                          letterSpacing: '0.25px',
+                          padding: '0 16px'
+                        }"
+                        class="github-signin-button"
+                      >
+                        <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
+                        <span style="color: #3c4043;">Sign in with GitHub</span>
+                      </v-btn>
+                    </div>
+                    <div v-if="isOidcOAuthEnabled" class="oauth-provider-buttons__cell">
+                      <v-btn
+                        variant="outlined"
+                        size="large"
+                        :disabled="isAuthenticatePending"
+                        @click="!isAuthenticatePending && loginWithOAuth('oidc')"
+                        :style="{
+                          height: '40px',
+                          width: 'auto',
+                          maxWidth: '100%',
+                          cursor: isAuthenticatePending ? 'not-allowed' : 'pointer',
+                          opacity: isAuthenticatePending ? 0.6 : 1,
+                          display: 'inline-flex',
+                          textTransform: 'none',
+                          fontSize: '14px',
+                          fontWeight: '500',
+                          padding: '0 16px'
+                        }"
+                      >
+                        <v-icon start size="18" class="mr-2">mdi-shield-key-outline</v-icon>
+                        {{ oidcSignInButtonLabel }}
+                      </v-btn>
+                    </div>
+                  </div>
                 </v-col>
               </v-row>
             </v-form>
@@ -186,7 +215,6 @@ import { getTextColorForBackground } from '@/genericHelpers';
 
 export default {
   name: 'Login',
-  components: {ForgotPasswordDialog, Main},
   components: {ForgotPasswordDialog, MarkdownViewer, Main},
   data() {
     return {
@@ -220,6 +248,24 @@ export default {
     },
     isGitHubOAuthEnabled() {
       return this.siteConfig?.oauth?.providers?.github?.enabled === true;
+    },
+    isOidcOAuthEnabled() {
+      return this.siteConfig?.oauth?.providers?.oidc?.enabled === true;
+    },
+    isAnyOAuthEnabled() {
+      return this.isGoogleOAuthEnabled || this.isGitHubOAuthEnabled || this.isOidcOAuthEnabled;
+    },
+    oidcSignInButtonLabel() {
+      const name = this.siteConfig?.oauth?.providers?.oidc?.signInWithName?.trim();
+      return `Sign in with ${name || 'SSO'}`;
+    },
+    oauthRedirectLabel() {
+      const p = this.oAuthRedirectingProvider;
+      const name = this.siteConfig?.oauth?.providers?.oidc?.signInWithName?.trim();
+      if (p === 'google') return 'Google';
+      if (p === 'github') return 'GitHub';
+      if (p === 'oidc') return name || 'SSO';
+      return '';
     },
   },
   mounted() {
@@ -292,6 +338,41 @@ export default {
 ::v-deep(.compact-banner .markdown h1),
 ::v-deep(.compact-banner .markdown h2) {
   margin: 0.25em 0;
+}
+
+.oauth-provider-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  justify-items: stretch;
+  width: 100%;
+}
+
+.oauth-provider-buttons__cell {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+}
+
+/* Center a lone last row (e.g. 3rd of 3, 5th of 5) under the row above */
+.oauth-provider-buttons__cell:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: auto;
+  max-width: 100%;
+}
+
+@media (max-width: 420px) {
+  .oauth-provider-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .oauth-provider-buttons__cell:last-child:nth-child(odd) {
+    grid-column: auto;
+    justify-self: stretch;
+    width: 100%;
+  }
 }
 
 </style>

--- a/frontend/src/views/OAuthComplete.vue
+++ b/frontend/src/views/OAuthComplete.vue
@@ -226,8 +226,11 @@ export default {
       ];
     },
     providerName() {
+      const name = this.siteConfig?.oauth?.providers?.oidc?.signInWithName?.trim();
       const providerMap = {
-        google: 'Google'
+        google: 'Google',
+        github: 'GitHub',
+        oidc: name || 'SSO'
       };
       return providerMap[this.oauthData.provider] || this.oauthData.provider;
     }

--- a/frontend/src/views/SignUp.vue
+++ b/frontend/src/views/SignUp.vue
@@ -16,25 +16,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           indeterminate
         ></v-progress-linear>
       </template>
-      <v-card-text v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="pb-4">
-        <div v-if="isOAuthRedirecting && (isGoogleOAuthEnabled || isGitHubOAuthEnabled)" class="d-flex flex-column align-center justify-center" style="min-height: 40px;">
+      <v-card-text v-if="isAnyOAuthEnabled" class="pb-4">
+        <div v-if="isOAuthRedirecting && isAnyOAuthEnabled" class="d-flex flex-column align-center justify-center" style="min-height: 40px;">
           <v-progress-circular
             indeterminate
             color="primary"
             size="40"
             width="4"
           ></v-progress-circular>
-          <span class="mt-2 text-caption text-grey">Redirecting to {{ oAuthRedirectingProvider === 'google' ? 'Google' : 'GitHub' }}...</span>
+          <span class="mt-2 text-caption text-grey">Redirecting to {{ oauthRedirectLabel }}...</span>
         </div>
-        <v-row v-else-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" no-gutters>
-          <v-col v-if="isGoogleOAuthEnabled" :cols="isGitHubOAuthEnabled ? 6 : 12" class="text-center" :class="isGitHubOAuthEnabled ? 'pr-1' : ''" style="position: relative;">
-            <img 
-              src="/img/google-signin-button.svg" 
+        <div v-else-if="isAnyOAuthEnabled" class="oauth-provider-buttons">
+          <div v-if="isGoogleOAuthEnabled" class="oauth-provider-buttons__cell">
+            <img
+              src="/img/google-signin-button.svg"
               alt="Sign in with Google"
               @click="!isCreatePending && loginWithOAuth('google')"
-              :style="{ 
-                height: '40px', 
-                width: 'auto', 
+              :style="{
+                height: '40px',
+                width: 'auto',
+                maxWidth: '100%',
                 cursor: isCreatePending ? 'not-allowed' : 'pointer',
                 opacity: isCreatePending ? 0.6 : 1,
                 display: 'block',
@@ -42,16 +43,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               }"
               class="google-signin-button"
             />
-          </v-col>
-          <v-col v-if="isGitHubOAuthEnabled" :cols="isGoogleOAuthEnabled ? 6 : 12" class="text-center" :class="isGoogleOAuthEnabled ? 'pl-1' : ''" style="position: relative;">
+          </div>
+          <div v-if="isGitHubOAuthEnabled" class="oauth-provider-buttons__cell">
             <v-btn
               variant="outlined"
               size="large"
               :disabled="isCreatePending"
               @click="!isCreatePending && loginWithOAuth('github')"
-              :style="{ 
+              :style="{
                 height: '40px',
                 width: 'auto',
+                maxWidth: '100%',
                 cursor: isCreatePending ? 'not-allowed' : 'pointer',
                 opacity: isCreatePending ? 0.6 : 1,
                 display: 'inline-flex',
@@ -71,9 +73,32 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               <v-icon start size="18" style="margin-right: 10px; color: #24292f;">mdi-github</v-icon>
               <span style="color: #3c4043;">Sign in with GitHub</span>
             </v-btn>
-          </v-col>
-        </v-row>
-        <div v-if="isGoogleOAuthEnabled || isGitHubOAuthEnabled" class="d-flex align-center my-3">
+          </div>
+          <div v-if="isOidcOAuthEnabled" class="oauth-provider-buttons__cell">
+            <v-btn
+              variant="outlined"
+              size="large"
+              :disabled="isCreatePending"
+              @click="!isCreatePending && loginWithOAuth('oidc')"
+              :style="{
+                height: '40px',
+                width: 'auto',
+                maxWidth: '100%',
+                cursor: isCreatePending ? 'not-allowed' : 'pointer',
+                opacity: isCreatePending ? 0.6 : 1,
+                display: 'inline-flex',
+                textTransform: 'none',
+                fontSize: '14px',
+                fontWeight: '500',
+                padding: '0 16px'
+              }"
+            >
+              <v-icon start size="18" class="mr-2">mdi-shield-key-outline</v-icon>
+              {{ oidcSignInButtonLabel }}
+            </v-btn>
+          </div>
+        </div>
+        <div v-if="isAnyOAuthEnabled" class="d-flex align-center my-3">
           <v-divider></v-divider>
           <span class="mx-4 text-grey">OR</span>
           <v-divider></v-divider>
@@ -295,6 +320,24 @@ export default {
     isGitHubOAuthEnabled() {
       return this.siteConfig?.oauth?.providers?.github?.enabled === true;
     },
+    isOidcOAuthEnabled() {
+      return this.siteConfig?.oauth?.providers?.oidc?.enabled === true;
+    },
+    isAnyOAuthEnabled() {
+      return this.isGoogleOAuthEnabled || this.isGitHubOAuthEnabled || this.isOidcOAuthEnabled;
+    },
+    oidcSignInButtonLabel() {
+      const name = this.siteConfig?.oauth?.providers?.oidc?.signInWithName?.trim();
+      return `Sign in with ${name || 'SSO'}`;
+    },
+    oauthRedirectLabel() {
+      const p = this.oAuthRedirectingProvider;
+      const name = this.siteConfig?.oauth?.providers?.oidc?.signInWithName?.trim();
+      if (p === 'google') return 'Google';
+      if (p === 'github') return 'GitHub';
+      if (p === 'oidc') return name || 'SSO';
+      return '';
+    },
     usageTypes() {
       return [
         { value: 'work', title: `I want to use ${this.siteConfig?.siteTitle} for work` },
@@ -401,5 +444,38 @@ export default {
 </script>
 
 <style scoped>
+.oauth-provider-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  justify-items: stretch;
+  width: 100%;
+}
 
+.oauth-provider-buttons__cell {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+}
+
+/* Center a lone last row (e.g. 3rd of 3, 5th of 5) under the row above */
+.oauth-provider-buttons__cell:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: auto;
+  max-width: 100%;
+}
+
+@media (max-width: 420px) {
+  .oauth-provider-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .oauth-provider-buttons__cell:last-child:nth-child(odd) {
+    grid-column: auto;
+    justify-self: stretch;
+    width: 100%;
+  }
+}
 </style>

--- a/frontend/src/views/XavierOAuthConfig.vue
+++ b/frontend/src/views/XavierOAuthConfig.vue
@@ -139,6 +139,140 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               </v-card-text>
             </v-card>
           </v-col>
+          <v-col cols="12">
+            <v-card class="ma-2" elevation="1">
+              <v-card-title>OpenID Connect (OIDC)</v-card-title>
+              <v-card-text>
+                <p class="text-caption text-grey-darken-1 mb-4">
+                  See the
+                  <a
+                    href="https://github.com/FreeCAD/Ondsel-Server/blob/main/docs/admin-panel.md#openid-connect-oidc"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >OpenID Connect (OIDC) setup instructions</a>
+                  in the OAuth Configuration documentation. Use the Redirect URI shown below when configuring your OIDC client.
+                </p>
+
+                <v-switch
+                  v-model="oidcConfig.enabled"
+                  label="Enable OIDC sign-in"
+                  color="primary"
+                ></v-switch>
+
+                <template v-if="!oidcConfig.enabled">
+                  <p class="text-caption text-grey-darken-1 mb-4">
+                    Enable OIDC sign-in above to configure Issuer URL, Client ID, Client Secret, sign-in label, and endpoint URLs.
+                  </p>
+                </template>
+
+                <v-text-field
+                  v-model="oidcConfig.issuer"
+                  label="Issuer URL"
+                  :rules="oidcRules.issuer"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="e.g. https://auth.example.com/realms/myrealm"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="oidcConfig.clientId"
+                  label="Client ID"
+                  :rules="oidcRules.clientId"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="OIDC client ID from your identity provider"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="oidcConfig.clientSecret"
+                  label="Client Secret"
+                  :rules="oidcRules.clientSecret"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="password"
+                  hint="OIDC client secret (masked for security)"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="oidcConfig.signInWithName"
+                  label="Sign-in button suffix"
+                  :rules="oidcRules.signInWithName"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="Text after “Sign in with” on login and sign-up (leave empty for SSO)"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-btn
+                  color="secondary"
+                  variant="tonal"
+                  class="mb-4"
+                  :disabled="isSaving || !oidcConfig.enabled || !oidcConfig.issuer?.trim() || isFetchingOidcEndpoints"
+                  :loading="isFetchingOidcEndpoints"
+                  @click="fetchOidcEndpoints"
+                >
+                  Fetch endpoints from issuer
+                </v-btn>
+
+                <v-text-field
+                  v-model="oidcConfig.authorizeUrl"
+                  label="Authorization endpoint URL"
+                  :rules="oidcRules.authorizeUrl"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="Paste from your IdP or use Fetch endpoints from issuer"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="oidcConfig.tokenUrl"
+                  label="Token endpoint URL"
+                  :rules="oidcRules.tokenUrl"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="Paste from your IdP or use Fetch endpoints from issuer"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  v-model="oidcConfig.userinfoUrl"
+                  label="Userinfo endpoint URL"
+                  :rules="oidcRules.userinfoUrl"
+                  :disabled="isSaving || !oidcConfig.enabled"
+                  type="text"
+                  hint="Paste from your IdP or use Fetch endpoints from issuer"
+                  persistent-hint
+                  class="mb-2"
+                ></v-text-field>
+
+                <v-text-field
+                  :model-value="oidcRedirectUri"
+                  label="Redirect URI"
+                  readonly
+                  hint="Use this redirect URI when configuring your OIDC client"
+                  persistent-hint
+                  class="mb-2"
+                >
+                  <template v-slot:append>
+                    <v-btn
+                      icon="mdi-content-copy"
+                      variant="text"
+                      size="small"
+                      @click="copyToClipboard(oidcRedirectUri)"
+                    ></v-btn>
+                  </template>
+                </v-text-field>
+              </v-card-text>
+            </v-card>
+          </v-col>
         </v-row>
       </v-form>
     </v-card-text>
@@ -183,6 +317,17 @@ export default {
         clientId: '',
         clientSecret: '',
       },
+      oidcConfig: {
+        enabled: false,
+        clientId: '',
+        clientSecret: '',
+        issuer: '',
+        authorizeUrl: '',
+        tokenUrl: '',
+        userinfoUrl: '',
+        signInWithName: '',
+      },
+      isFetchingOidcEndpoints: false,
       showSnackbar: false,
       snackbarMessage: '',
       snackbarColor: 'success',
@@ -214,6 +359,51 @@ export default {
           }
         ],
       },
+      oidcRules: {
+        issuer: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Issuer URL is required when OIDC is enabled';
+          }
+        ],
+        clientId: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Client ID is required when OIDC is enabled';
+          }
+        ],
+        clientSecret: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Client Secret is required when OIDC is enabled';
+          }
+        ],
+        signInWithName: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            if (!v || !String(v).trim()) return true;
+            return String(v).trim().length <= 20 || 'Use at most 20 characters';
+          }
+        ],
+        authorizeUrl: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Authorization endpoint URL is required when OIDC is enabled';
+          }
+        ],
+        tokenUrl: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Token endpoint URL is required when OIDC is enabled';
+          }
+        ],
+        userinfoUrl: [
+          v => {
+            if (!this.oidcConfig.enabled) return true;
+            return !!v?.trim() || 'Userinfo endpoint URL is required when OIDC is enabled';
+          }
+        ],
+      },
     }
   },
   async created() {
@@ -225,7 +415,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('auth', ['user']),
+    ...mapState('auth', ['user', 'accessToken']),
     ...mapGetters('app', ['siteConfig']),
     googleRedirectUri() {
       const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
@@ -234,6 +424,10 @@ export default {
     githubRedirectUri() {
       const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
       return `${baseUrl}/oauth/github/callback`;
+    },
+    oidcRedirectUri() {
+      const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
+      return `${baseUrl}/oauth/oidc/callback`;
     },
   },
   watch: {
@@ -254,6 +448,19 @@ export default {
               clientSecret: newVal.oauth.providers.github.clientSecret || '',
             };
           }
+          if (newVal.oauth.providers.oidc && !this.oidcConfig.clientId) {
+            const o = newVal.oauth.providers.oidc;
+            this.oidcConfig = {
+              enabled: o.enabled || false,
+              clientId: o.clientId || '',
+              clientSecret: o.clientSecret || '',
+              issuer: o.issuer || '',
+              authorizeUrl: o.authorizeUrl || '',
+              tokenUrl: o.tokenUrl || '',
+              userinfoUrl: o.userinfoUrl || '',
+              signInWithName: o.signInWithName || '',
+            };
+          }
         }
       },
       immediate: true,
@@ -269,6 +476,13 @@ export default {
     },
     'githubConfig.enabled'() {
       // Trigger validation when enabled state changes
+      this.$nextTick(() => {
+        if (this.$refs.form) {
+          this.$refs.form.validate();
+        }
+      });
+    },
+    'oidcConfig.enabled'() {
       this.$nextTick(() => {
         if (this.$refs.form) {
           this.$refs.form.validate();
@@ -299,6 +513,17 @@ export default {
               clientSecret: this.githubConfig.clientSecret.trim(),
               redirectUri: this.githubRedirectUri,
             },
+            oidc: {
+              enabled: this.oidcConfig.enabled,
+              clientId: this.oidcConfig.clientId.trim(),
+              clientSecret: this.oidcConfig.clientSecret.trim(),
+              redirectUri: this.oidcRedirectUri,
+              issuer: this.oidcConfig.issuer.trim(),
+              authorizeUrl: (this.oidcConfig.authorizeUrl || '').trim(),
+              tokenUrl: (this.oidcConfig.tokenUrl || '').trim(),
+              userinfoUrl: (this.oidcConfig.userinfoUrl || '').trim(),
+              signInWithName: (this.oidcConfig.signInWithName || '').trim().slice(0, 20),
+            },
           }
         };
 
@@ -326,7 +551,39 @@ export default {
       this.snackbarMessage = message;
       this.snackbarColor = color;
       this.showSnackbar = true;
-    }
+    },
+    async fetchOidcEndpoints() {
+      this.isFetchingOidcEndpoints = true;
+      try {
+        const baseUrl = import.meta.env.VITE_APP_API_URL?.replace(/\/$/, '') || window.location.origin;
+        const res = await fetch(`${baseUrl}/oidc-discovery`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: this.accessToken,
+          },
+          body: JSON.stringify({ issuer: this.oidcConfig.issuer.trim() }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(data.error || `Discovery failed (${res.status})`);
+        }
+        this.oidcConfig.authorizeUrl = data.authorizeUrl || '';
+        this.oidcConfig.tokenUrl = data.tokenUrl || '';
+        this.oidcConfig.userinfoUrl = data.userinfoUrl || '';
+        this.showMessage('Endpoints loaded from issuer', 'success');
+        this.$nextTick(() => {
+          if (this.$refs.form) {
+            this.$refs.form.validate();
+          }
+        });
+      } catch (e) {
+        console.error(e);
+        this.showMessage(e.message || 'OIDC discovery failed', 'error');
+      } finally {
+        this.isFetchingOidcEndpoints = false;
+      }
+    },
   }
 }
 </script>


### PR DESCRIPTION
## Summary

Adds OpenID Connect (OIDC) support so Lens can integrate with self-hosted identity providers like Keycloak, alongside the existing Google and GitHub OAuth (FPA Grant #60). Resolves [FreeCAD/Ondsel-Server#62](https://github.com/FreeCAD/Ondsel-Server/issues/62).

All configuration is managed from the Xavier admin panel and applied at runtime — no env-vars, no restart required.

## What's included

**Backend**
- New `OidcStrategy` (userinfo-based) wired into Grant dynamically from `site-config.oauth.providers.oidc`; site-config updates reload the OAuth config without a restart.
- New authenticated, site-admin-only `POST /oidc-discovery` endpoint that reads `/.well-known/openid-configuration` for the admin UI's "Fetch endpoints from issuer" button.
- Schema updates: `oauth.providers.oidc` on site-config, `oauthProviders.oidc.id` on users; public site-config filter exposes only `{ enabled, signInWithName }` (no secrets).
- Migrations: `addOidcProviderToSiteConfig` (idempotent, wired into `entry.sh`) and dev-only `seedDevKeycloakOidcSiteConfig`.

**Frontend**
- New OIDC section in `XavierOAuthConfig.vue` (issuer, client ID/secret, sign-in button suffix, endpoint fields, discovery button, redirect URI).
- "Sign in with &lt;name&gt;" (or "SSO") button on Login and SignUp; OAuth buttons refactored into a responsive grid that handles 1–3 providers cleanly.
- `OAuthComplete.vue` recognizes the `oidc` provider.

**Local dev (Keycloak)**
- New `keycloak` profile in `docker-compose.dev.yml` (Keycloak 26.6.1) with a pre-imported `lens` realm (`lens-backend` client + test user `admin@local.test`).
- `env.example`, `README.md`, and `docs/admin-panel.md` updated with the OIDC setup steps and defaults.

## Test plan

```bash
docker-compose -f docker-compose.dev.yml --profile keycloak up --build -d
docker-compose -f docker-compose.dev.yml exec backend npm run migration seedDevKeycloakOidcSiteConfig
docker-compose -f docker-compose.dev.yml restart backend
```

Then sign in at `http://localhost:3000/login` → **Sign in with SSO** → Keycloak (`admin@local.test` / `admin@local.test`).

## Screenshots

<img width="1915" height="986" alt="image" src="https://github.com/user-attachments/assets/15455cbb-180b-43e4-aa58-160f106d3e6e" />
<img width="1915" height="986" alt="image" src="https://github.com/user-attachments/assets/0d5ad62c-f903-4bae-9a2c-26b772bfeff0" />
<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/bff67ede-fff7-49aa-9a76-af5b77aaa2c0" />
<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/c43381da-2da2-4a51-9346-324a64295154" />


## Commits

- `0c2a54f` feat(oauth): add OIDC configuration to admin panel
- `1c85f25` feat(oauth): add OIDC strategy and login/sign-up integration
- `304149a` feat(oauth): add Keycloak profile and OIDC seed migration for development